### PR TITLE
Support for config override

### DIFF
--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -974,9 +974,8 @@ void raft_server::become_leader() {
             if (last_config->get_log_idx() > ii)
             {
                 p_wn("Currently assigned config is newer than some "
-                     "uncomitted config. This can only happen during "
-                     "force recovery. If force recovery is not currently "
-                     "in progress, this is a bug.");
+                     "uncomitted config. This can only happen during startup or "
+                     "force recovery. If that is not the case, this is a bug.");
                 break;
             }
 

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -971,6 +971,15 @@ void raft_server::become_leader() {
             ptr<log_entry> le = log_store_->entry_at(ii);
             if (le->get_val_type() != log_val_type::conf) continue;
 
+            if (last_config->get_log_idx() > ii)
+            {
+                p_wn("Currently assigned config is newer than some "
+                     "uncomitted config. This can only happen during "
+                     "force recovery. If force recovery is not currently "
+                     "in progress, this is a bug.");
+                break;
+            }
+
             p_in("found uncommitted config at %zu, size %zu",
                  ii, le->get_buf().size());
             last_config = cluster_config::deserialize(le->get_buf());


### PR DESCRIPTION
Once a node becomes a leader it will find the latest config to append to LogStore.
With this change it will prefer config that we manually set if it's newer than uncommitted configs, allowing us to override config of the cluster.