### PR TITLE
Pause state machine while snapshot is synced

### DIFF
--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -222,9 +222,18 @@ bool raft_server::commit_in_bg_exec(size_t timeout_ms, bool initial_commit_exec)
         }
 
         ulong index_to_commit = sm_commit_index_ + 1;
-        ptr<log_entry> le = log_store_->entry_at(index_to_commit);
         p_tr( "commit upto %llu, current idx %llu\n",
               quick_commit_index_.load(), index_to_commit );
+
+        ptr<log_entry> le = log_store_->entry_at(index_to_commit);
+        if (!le)
+        {
+            // LCOV_EXCL_START
+            p_ft( "failed to get log entry with idx %llu", index_to_commit );
+            ctx_->state_mgr_->system_exit(raft_err::N19_bad_log_idx_for_term);
+            ::exit(-1);
+            // LCOV_EXCL_STOP
+        }
 
         if (le->get_term() == 0) {
             // LCOV_EXCL_START

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -882,7 +882,7 @@ void raft_server::pause_state_machine_exeuction(size_t timeout_ms) {
 }
 
 void raft_server::resume_state_machine_execution() {
-    p_in( "pause state machine execution, previously %s, state machine %s",
+    p_in( "resume state machine execution, previously %s, state machine %s",
           sm_commit_paused_ ? "PAUSED" : "ACTIVE",
           sm_commit_exec_in_progress_ ? "RUNNING" : "SLEEPING" );
     sm_commit_paused_ = false;


### PR DESCRIPTION
Snapshot sync can call log compaction while committing is done at the same time in the background.
This can happen during the initial log commit when the follower doesn't know it will receive a snapshot just that it needs to commit all the logs.

To prevent this, we pause the bg commit thread while sync is in progress.
No other place calls log compaction apart from the commit thread itself.
