### PR TITLE
Fix shutdown during commit and increase allowed request size

### DIFF
--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -376,7 +376,7 @@ public:
                 return;
             }
 
-            if (data_size > 0x20000000) {
+            if (data_size > 0x40000000) {
                 p_wn("large data size in the header %d", data_size);
             }
 

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -368,12 +368,16 @@ public:
             header_->pos(RPC_REQ_HEADER_SIZE - CRC_FLAGS_LEN - DATA_SIZE_LEN);
             int32 data_size = header_->get_int();
             // Up to 1GB.
-            if (data_size < 0 || data_size > 0x40000000) {
+            if (data_size < 0) {
                 p_er("bad log data size in the header %d, stop "
                      "this session to protect further corruption",
                      data_size);
                 this->stop();
                 return;
+            }
+
+            if (data_size > 0x20000000) {
+                p_wn("large data size in the header %d", data_size);
             }
 
             if (data_size == 0) {

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -367,7 +367,7 @@ public:
 
             header_->pos(RPC_REQ_HEADER_SIZE - CRC_FLAGS_LEN - DATA_SIZE_LEN);
             int32 data_size = header_->get_int();
-            // Up to 1GB.
+            
             if (data_size < 0) {
                 p_er("bad log data size in the header %d, stop "
                      "this session to protect further corruption",
@@ -375,7 +375,7 @@ public:
                 this->stop();
                 return;
             }
-
+            // Warning for 1GB+
             if (data_size > 0x40000000) {
                 p_wn("large data size in the header %d", data_size);
             }


### PR DESCRIPTION
While the commit is being executed, it's not checked if shutdown was called making it inconvenient to shutdown during commit of a large number of logs (e.g. during startup).

Some requests can be larger (for example sending large snapshots) so we remove the upper limit (not counting the integer limit)