### PR TITLE
Allowing clients to provide pre-Configured SSL_CTX for both client and server use-cases.

### DIFF
--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -21,6 +21,9 @@ limitations under the License.
 #include <string>
 #include <system_error>
 
+
+typedef struct ssl_ctx_st SSL_CTX;
+
 namespace nuraft {
 
 /**
@@ -172,6 +175,10 @@ struct asio_service_options {
     // If true will try to load CA from default path
     // call (SSL_CTX_set_default_verify_paths)
     bool load_default_ca_file_;
+
+    // If set, will use SSL_CTX povided by callback
+    std::function<SSL_CTX* (void)> ssl_context_provider_server_;
+    std::function<SSL_CTX* (void)> ssl_context_provider_client_;
 
     /**
      * Custom IP address resolver. If given, it will be invoked

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1627,7 +1627,7 @@ void _timer_handler_(ptr<delayed_task>& task, ERROR_CODE err) {
 
 namespace {
 
-ssl_context get_or_create_ssl_context(auto ctx_provider_func, ssl_context::method method) {
+ssl_context get_or_create_ssl_context(std::function<SSL_CTX* (void)> ctx_provider_func, ssl_context::method method) {
     if (ctx_provider_func)
         return ssl_context(ctx_provider_func());
     else


### PR DESCRIPTION
Current way of configuring SSL_CTX lacks important features, there are currently no way to: 
- set DH params (SSL_CTX_set_tmp_dh)
- restrict set of ciphers to use or not to use (SSL_CTX_set_cipher_list) 
- disable some protocols  (SSL_CTX_set_options)
- and many others (SSL_CTX_set_verify_depth, SSL_CTX_set_session_cache_mode, SSL_CTX_set_mode)

While all of those are supported by ClickHouse through Poco, and are really useful in some cases.

To avoid adding too many configuration parameters to the `asio_service_options`, two new callbacks were added:
- `std::function<SSL_CTX* (void)> ssl_context_provider_server_`
- `std::function<SSL_CTX* (void)> ssl_context_provider_client_`

Which provide preconfigured, ready to use SSL_CTX, so the clients of the library may configure contexts in any required way.