### PR TITLE
Add a new param to enable ipv6 or not for raft_launch::init()

### DIFF
--- a/include/libnuraft/launcher.hxx
+++ b/include/libnuraft/launcher.hxx
@@ -48,7 +48,8 @@ public:
                           int port_number,
                           const asio_service::options& asio_options,
                           const raft_params& params,
-                          const raft_server::init_options& opt = raft_server::init_options());
+                          const raft_server::init_options& opt = raft_server::init_options(),
+                          const bool enable_ipv6 = true);
 
     /**
      * Shutdown Raft server and ASIO service.

--- a/src/launcher.cxx
+++ b/src/launcher.cxx
@@ -32,11 +32,12 @@ ptr<raft_server> raft_launcher::init(ptr<state_machine> sm,
                                      int port_number,
                                      const asio_service::options& asio_options,
                                      const raft_params& params_given,
-                                     const raft_server::init_options& opt)
+                                     const raft_server::init_options& opt,
+                                     const bool enable_ipv6)
 {
     asio_svc_ = cs_new<asio_service>(asio_options, lg);
 
-    auto asio_listener = asio_svc_->create_rpc_listener(port_number, lg);
+    auto asio_listener = asio_svc_->create_rpc_listener(port_number, lg, enable_ipv6);
     if (!asio_listener) return nullptr;
 
     asio_listeners_.emplace_back(std::move(asio_listener));


### PR DESCRIPTION
The function 'raft_launch::init()' only supports ipv6, let's add a new parameter to support ipv4. Then we can run unit tests of clickhouse with ipv4.