### PR TITLE
Fix deadlock during snapshot sync

### DIFF
--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -20,6 +20,7 @@ limitations under the License.
 #include <functional>
 #include <string>
 #include <system_error>
+#include <cstdint>
 
 
 typedef struct ssl_ctx_st SSL_CTX;

--- a/include/libnuraft/callback.hxx
+++ b/include/libnuraft/callback.hxx
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <functional>
 #include <string>
+#include <cstdint>
 
 namespace nuraft {
 

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -524,23 +524,6 @@ bool raft_server::handle_snapshot_sync_req(snapshot_sync_req& req) {
     }
 
     if (is_last_obj) {
-        // let's pause committing in backgroud so it doesn't access logs
-        // while they are being compacted
-        pause_state_machine_exeuction();
-
-        size_t wait_count = 0;
-        while (!wait_for_state_machine_pause(500)) {
-            p_in("waiting for state machine pause before applying snapshot: count %zu",
-                 ++wait_count);
-        }
-
-        struct ExecAutoResume {
-            explicit ExecAutoResume(std::function<void()> func) : clean_func_(func) {}
-            ~ExecAutoResume() { clean_func_(); }
-            std::function<void()> clean_func_;
-        } exec_auto_resume([this](){ resume_state_machine_execution(); });
-
-
         receiving_snapshot_ = false;
 
         // Only follower will run this piece of code, but let's check it again


### PR DESCRIPTION
Committing config logs requires global lock which is taken during snapshot install.
Snapshot install will wait for the commit thread to pause before continuing leading to a deadlock.