### PR TITLE
Fix election RPC timeout handling

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -242,7 +242,8 @@ public:
     void send_req(ptr<peer> myself,
                   ptr<req_msg>& req,
                   rpc_handler& handler,
-                  bool streaming = false);
+                  bool streaming = false,
+                  uint64_t send_timeout_ms = 0);
 
     void shutdown();
 

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -1082,7 +1082,7 @@ protected:
     bool check_cond_for_zp_election();
     void request_prevote();
     void initiate_vote(bool force_vote = false);
-    void request_vote(bool force_vote);
+    void request_vote(bool force_vote, uint64_t election_rpc_timeout_ms);
     void request_append_entries();
     bool request_append_entries(ptr<peer> p);
     bool send_request(ptr<peer>& p,

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1594,20 +1594,33 @@ public:
                   this, host_.c_str(), port_.c_str() );
 
             if (impl_->get_options().custom_resolver_) {
-                impl_->get_options().custom_resolver_(
-                    host_,
-                    port_,
-                    [this, self, req, when_done, send_timeout_ms]
-                    ( const std::string& resolved_host,
-                      const std::string& resolved_port,
-                      std::error_code err ) {
-                        if (!err) {
-                            p_in( "custom resolver: %s:%s to %s:%s",
-                                  host_.c_str(), port_.c_str(),
-                                  resolved_host.c_str(), resolved_port.c_str() );
-                            execute_resolver(self, req, resolved_host, resolved_port,
-                                             when_done, send_timeout_ms);
-                        } else {
+                std::string completion_error_msg;
+                auto custom_resolver_callback_invoked =
+                    std::make_shared<std::atomic<bool>>(false);
+                try {
+                    impl_->get_options().custom_resolver_(
+                        host_,
+                        port_,
+                        [this,
+                         self,
+                         req,
+                         when_done,
+                         send_timeout_ms,
+                         custom_resolver_callback_invoked]
+                        ( const std::string& resolved_host,
+                          const std::string& resolved_port,
+                          std::error_code err ) {
+                            custom_resolver_callback_invoked
+                                ->store(true, std::memory_order_relaxed);
+                            if (!err) {
+                                p_in( "custom resolver: %s:%s to %s:%s",
+                                      host_.c_str(), port_.c_str(),
+                                      resolved_host.c_str(), resolved_port.c_str() );
+                                execute_resolver(self, req, resolved_host, resolved_port,
+                                                 when_done, send_timeout_ms);
+                                return;
+                            }
+
                             std::string err_msg = lstrfmt("failed to resolve "
                                                           "host %s by given "
                                                           "custom resolver "
@@ -1615,40 +1628,73 @@ public:
                                                           .fmt( host_.c_str(),
                                                                 err.value(),
                                                                 err.message().c_str() );
+                            clear_busy_flag_if_set(false);
                             handle_error(req, err_msg, when_done);
-                        }
-                    } );
+                        } );
+                } catch (const std::exception& e) {
+                    if (custom_resolver_callback_invoked->load(std::memory_order_relaxed)) {
+                        throw;
+                    }
+                    send_timer_.cancel();
+                    completion_error_msg =
+                        setup_exception_message("custom resolver setup", req, e);
+                } catch (...) {
+                    if (custom_resolver_callback_invoked->load(std::memory_order_relaxed)) {
+                        throw;
+                    }
+                    send_timer_.cancel();
+                    completion_error_msg =
+                        setup_unknown_exception_message("custom resolver setup", req);
+                }
+
+                if (!completion_error_msg.empty()) {
+                    clear_busy_flag_if_set(false);
+                    handle_error(req, completion_error_msg, when_done);
+                }
             } else {
                 execute_resolver(self, req, host_, port_, when_done, send_timeout_ms);
             }
             return;
         }
 
-        ptr<buffer> req_buf = serialize_req(req);
+        try {
+            ptr<buffer> req_buf = serialize_req(req);
 
-        if (send_timeout_ms != 0)
-        {
-            send_timer_.expires_after
-                   ( std::chrono::duration_cast<std::chrono::nanoseconds>
-                     ( std::chrono::milliseconds( send_timeout_ms ) ) );
-            send_timer_.async_wait( std::bind( &asio_rpc_client::cancel_socket,
-                                               this,
-                                               std::placeholders::_1 ) );
+            if (send_timeout_ms != 0)
+            {
+                send_timer_.expires_after
+                       ( std::chrono::duration_cast<std::chrono::nanoseconds>
+                         ( std::chrono::milliseconds( send_timeout_ms ) ) );
+                send_timer_.async_wait(
+                    [self](const ERROR_CODE& err) {
+                        self->cancel_socket(err);
+                    } );
+            }
+
+            // Note: without passing `req_buf` to callback function, it will be
+            //       unreachable before the write is done so that it is freed
+            //       and the memory corruption will occur.
+            aa::write( ssl_enabled_, ssl_socket_, socket_,
+                       asio::buffer(req_buf->data(), req_buf->size()),
+                       std::bind( &asio_rpc_client::sent,
+                                  self,
+                                  req,
+                                  req_buf,
+                                  when_done,
+                                  send_timeout_ms,
+                                  std::placeholders::_1,
+                                  std::placeholders::_2 ) );
+        } catch (const std::exception& e) {
+            send_timer_.cancel();
+            clear_busy_flag_if_set(false);
+            std::string err_msg = setup_exception_message("request send setup", req, e);
+            handle_error(req, err_msg, when_done);
+        } catch (...) {
+            send_timer_.cancel();
+            clear_busy_flag_if_set(false);
+            std::string err_msg = setup_unknown_exception_message("request send setup", req);
+            handle_error(req, err_msg, when_done);
         }
-
-        // Note: without passing `req_buf` to callback function, it will be
-        //       unreachable before the write is done so that it is freed
-        //       and the memory corruption will occur.
-        aa::write( ssl_enabled_, ssl_socket_, socket_,
-                   asio::buffer(req_buf->data(), req_buf->size()),
-                   std::bind( &asio_rpc_client::sent,
-                              self,
-                              req,
-                              req_buf,
-                              when_done,
-                              send_timeout_ms,
-                              std::placeholders::_1,
-                              std::placeholders::_2 ) );
     }
 private:
     void execute_resolver(ptr<asio_rpc_client> self,
@@ -1658,44 +1704,81 @@ private:
                           rpc_handler when_done,
                           uint64_t send_timeout_ms) {
 
-        resolver_.async_resolve
-        (
-            host,
-            port,
-            asio::ip::tcp::resolver::flags::all_matching,
-            [self, this, req, when_done, host, port, send_timeout_ms](
-                const std::error_code& err,
-                asio::ip::tcp::resolver::results_type endpoints ) -> void
-        {
-            if (!err) {
-                if (send_timeout_ms != 0) {
-                    send_timer_.expires_after
-                    ( std::chrono::duration_cast<std::chrono::nanoseconds>
-                      ( std::chrono::milliseconds( send_timeout_ms ) ) );
-                    send_timer_.async_wait(
-                        std::bind( &asio_rpc_client::cancel_socket,
-                                   this,
-                                   std::placeholders::_1 ) );
+        std::string setup_error_msg;
+        try {
+            resolver_.async_resolve
+            (
+                host,
+                port,
+                asio::ip::tcp::resolver::flags::all_matching,
+                [self,
+                 this,
+                 req,
+                 when_done,
+                 host,
+                 port,
+                 send_timeout_ms](
+                    const std::error_code& err,
+                    asio::ip::tcp::resolver::results_type endpoints ) -> void
+            {
+                std::string completion_error_msg;
+                try {
+                    if (!err) {
+                        if (send_timeout_ms != 0) {
+                            send_timer_.expires_after
+                            ( std::chrono::duration_cast<std::chrono::nanoseconds>
+                              ( std::chrono::milliseconds( send_timeout_ms ) ) );
+                            send_timer_.async_wait(
+                                [self](const ERROR_CODE& timer_err) {
+                                    self->cancel_socket(timer_err);
+                                } );
+                        }
+                        asio::async_connect
+                            ( socket(),
+                              endpoints,
+                              std::bind( &asio_rpc_client::connected,
+                                         self,
+                                         req,
+                                         when_done,
+                                         send_timeout_ms,
+                                         std::placeholders::_1,
+                                         std::placeholders::_2 ) );
+                        return;
+                    } else {
+                        completion_error_msg =
+                            lstrfmt("failed to resolve host %s "
+                                    "due to error %d, %s")
+                                    .fmt( host.c_str(),
+                                          err.value(),
+                                          err.message().c_str() );
+                    }
+                } catch (const std::exception& e) {
+                    send_timer_.cancel();
+                    completion_error_msg =
+                        setup_exception_message("resolver completion", req, e);
+                } catch (...) {
+                    send_timer_.cancel();
+                    completion_error_msg =
+                        setup_unknown_exception_message("resolver completion", req);
                 }
-                asio::async_connect
-                    ( socket(),
-                      endpoints,
-                      std::bind( &asio_rpc_client::connected,
-                                 self,
-                                 req,
-                                 when_done,
-                                 send_timeout_ms,
-                                 std::placeholders::_1,
-                                 std::placeholders::_2 ) );
-            } else {
-                std::string err_msg = lstrfmt("failed to resolve host %s "
-                                              "due to error %d, %s")
-                                              .fmt( host.c_str(),
-                                                    err.value(),
-                                                    err.message().c_str() );
-                handle_error(req, err_msg, when_done);
-            }
-        } );
+
+                if (!completion_error_msg.empty()) {
+                    clear_busy_flag_if_set(false);
+                    handle_error(req, completion_error_msg, when_done);
+                }
+            } );
+        } catch (const std::exception& e) {
+            send_timer_.cancel();
+            setup_error_msg = setup_exception_message("resolver setup", req, e);
+        } catch (...) {
+            send_timer_.cancel();
+            setup_error_msg = setup_unknown_exception_message("resolver setup", req);
+        }
+
+        if (!setup_error_msg.empty()) {
+            clear_busy_flag_if_set(false);
+            handle_error(req, setup_error_msg, when_done);
+        }
     }
 
     void set_busy_flag(bool receive, bool busy) {
@@ -1708,6 +1791,29 @@ private:
             assert(0);
         }
         flag = busy;
+    }
+
+    // Use only from the same per-direction ASIO chain that owns the flag.
+    // The flags are non-atomic and this helper is not a cross-thread
+    // synchronization primitive.
+    void clear_busy_flag_if_set(bool receive) {
+        bool& flag = receive ? receive_busy_ : send_busy_;
+        if (flag) {
+            set_busy_flag(receive, false);
+        }
+    }
+
+    std::string setup_exception_message(const char* phase,
+                                        const ptr<req_msg>& req,
+                                        const std::exception& e) {
+        return lstrfmt("exception during %s for peer %d, %s:%s: %s")
+            .fmt(phase, req->get_dst(), host_.c_str(), port_.c_str(), e.what());
+    }
+
+    std::string setup_unknown_exception_message(const char* phase,
+                                                const ptr<req_msg>& req) {
+        return lstrfmt("unknown exception during %s for peer %d, %s:%s")
+            .fmt(phase, req->get_dst(), host_.c_str(), port_.c_str());
     }
 
     void handle_error(ptr<req_msg> req,
@@ -1730,7 +1836,22 @@ private:
         if (!impl_->get_options().streaming_mode_) {
             ptr<resp_msg> resp;
             ptr<rpc_exception> except(cs_new<rpc_exception>(err_msg, req));
-            when_done(resp, except);
+            invoke_rpc_error_callback(req, when_done, resp, except);
+        }
+    }
+
+    void invoke_rpc_error_callback(const ptr<req_msg>& req,
+                                   rpc_handler& when_done,
+                                   ptr<resp_msg>& rsp,
+                                   ptr<rpc_exception>& except) {
+        try {
+            when_done(rsp, except);
+        } catch (const std::exception& e) {
+            p_er("RPC error callback for peer %d threw exception: %s",
+                 req->get_dst(), e.what());
+        } catch (...) {
+            p_er("RPC error callback for peer %d threw unknown exception",
+                 req->get_dst());
         }
     }
 
@@ -1787,7 +1908,7 @@ private:
                 err_msg = lstrfmt("socket to host %s is closed").fmt( host_.c_str() );
             }
             ptr<rpc_exception> except( cs_new<rpc_exception>( err_msg, pkg->req_) );
-            pkg->when_done_(rsp, except);
+            invoke_rpc_error_callback(pkg->req_, pkg->when_done_, rsp, except);
         }
 
         ptr<req_msg> last_req;
@@ -1820,32 +1941,45 @@ private:
                    const asio::ip::tcp::endpoint&)
     {
         if (!err) {
-            asio::ip::tcp::no_delay option(true);
-            socket().set_option(option);
-            p_in( "%p connected to %s:%s (as a client)",
-                  this, host_.c_str(), port_.c_str() );
-            if (ssl_enabled_) {
+            try {
+                asio::ip::tcp::no_delay option(true);
+                socket().set_option(option);
+                p_in( "%p connected to %s:%s (as a client)",
+                      this, host_.c_str(), port_.c_str() );
+                if (ssl_enabled_) {
 #ifdef SSL_LIBRARY_NOT_FOUND
-                assert(0); // Should not reach here.
+                    assert(0); // Should not reach here.
 #else
-                ptr<asio_rpc_client> self = this->shared_from_this();
-                ssl_socket_.async_handshake
-                    ( asio::ssl::stream_base::client,
-                      std::bind( &asio_rpc_client::handle_handshake,
-                                 self,
-                                 req,
-                                 when_done,
-                                 send_timeout_ms,
-                                 std::placeholders::_1 ) );
+                    ptr<asio_rpc_client> self = this->shared_from_this();
+                    ssl_socket_.async_handshake
+                        ( asio::ssl::stream_base::client,
+                          std::bind( &asio_rpc_client::handle_handshake,
+                                     self,
+                                     req,
+                                     when_done,
+                                     send_timeout_ms,
+                                     std::placeholders::_1 ) );
 #endif
-            } else {
+                } else {
+                    send_timer_.cancel();
+                    set_busy_flag(/*receive=*/ false, /*busy=*/ false);
+                    this->register_req_send(req, when_done, send_timeout_ms);
+                }
+            } catch (const std::exception& e) {
                 send_timer_.cancel();
-                set_busy_flag(/*receive=*/ false, /*busy=*/ false);
-                this->register_req_send(req, when_done, send_timeout_ms);
+                clear_busy_flag_if_set(false);
+                std::string err_msg = setup_exception_message("connect completion", req, e);
+                handle_error(req, err_msg, when_done);
+            } catch (...) {
+                send_timer_.cancel();
+                clear_busy_flag_if_set(false);
+                std::string err_msg = setup_unknown_exception_message("connect completion", req);
+                handle_error(req, err_msg, when_done);
             }
 
         } else {
             send_timer_.cancel();
+            clear_busy_flag_if_set(false);
             std::string err_msg = sstrfmt("failed to connect to "
                                           "peer %d, %s:%s, error %d, %s")
                                           .fmt( req->get_dst(), host_.c_str(),
@@ -1861,13 +1995,22 @@ private:
                           const ERROR_CODE& err)
     {
         send_timer_.cancel();
-        ptr<asio_rpc_client> self = this->shared_from_this();
 
         if (!err) {
-            p_in( "handshake with %s:%s succeeded (as a client)",
-                  host_.c_str(), port_.c_str() );
-            set_busy_flag(/*receive=*/ false, /*busy=*/ false);
-            this->register_req_send(req, when_done, send_timeout_ms);
+            try {
+                p_in( "handshake with %s:%s succeeded (as a client)",
+                      host_.c_str(), port_.c_str() );
+                set_busy_flag(/*receive=*/ false, /*busy=*/ false);
+                this->register_req_send(req, when_done, send_timeout_ms);
+            } catch (const std::exception& e) {
+                clear_busy_flag_if_set(false);
+                std::string err_msg = setup_exception_message("handshake completion", req, e);
+                handle_error(req, err_msg, when_done);
+            } catch (...) {
+                clear_busy_flag_if_set(false);
+                std::string err_msg = setup_unknown_exception_message("handshake completion", req);
+                handle_error(req, err_msg, when_done);
+            }
 
         } else {
             p_er( "failed SSL handshake with peer %d, %s:%s, error %d, %s",
@@ -1880,6 +2023,7 @@ private:
                                           .fmt( req->get_dst(), host_.c_str(),
                                                 port_.c_str(), err.value(),
                                                 err.message().c_str() );
+            clear_busy_flag_if_set(false);
             handle_error(req, err_msg, when_done);
         }
     }
@@ -1896,13 +2040,22 @@ private:
         send_timer_.cancel();
         if (!err) {
             set_busy_flag(/*receive=*/ false, /*busy=*/ false);
-            uint64_t receive_timeout_ms = send_timeout_ms;
-            if (impl_->get_options().streaming_mode_) {
-                post_send(req, when_done, receive_timeout_ms);
-            } else {
-                register_response_read(req, when_done, receive_timeout_ms);
+            try {
+                uint64_t receive_timeout_ms = send_timeout_ms;
+                if (impl_->get_options().streaming_mode_) {
+                    post_send(req, when_done, receive_timeout_ms);
+                } else {
+                    register_response_read(req, when_done, receive_timeout_ms);
+                }
+            } catch (const std::exception& e) {
+                std::string err_msg = setup_exception_message("post-send setup", req, e);
+                handle_error(req, err_msg, when_done);
+            } catch (...) {
+                std::string err_msg = setup_unknown_exception_message("post-send setup", req);
+                handle_error(req, err_msg, when_done);
             }
         } else {
+            clear_busy_flag_if_set(false);
             std::string err_msg = sstrfmt( "failed to send request to peer %d, %s:%s, "
                                            "error %d, %s" )
                                            .fmt( req->get_dst(), host_.c_str(),
@@ -1963,25 +2116,37 @@ private:
     {
         ptr<asio_rpc_client> self(this->shared_from_this());
         set_busy_flag(/*receive=*/ true, /*busy=*/ true);
-        if (receive_timeout_ms != 0) {
-            receive_timer_.expires_after
-            ( std::chrono::duration_cast<std::chrono::nanoseconds>
-                ( std::chrono::milliseconds( receive_timeout_ms ) ) );
-            receive_timer_.async_wait(
-                std::bind( &asio_rpc_client::cancel_socket,
-                            this,
-                            std::placeholders::_1 ) );
+        try {
+            if (receive_timeout_ms != 0) {
+                receive_timer_.expires_after
+                ( std::chrono::duration_cast<std::chrono::nanoseconds>
+                    ( std::chrono::milliseconds( receive_timeout_ms ) ) );
+                receive_timer_.async_wait(
+                    [self](const ERROR_CODE& err) {
+                        self->cancel_socket(err);
+                    } );
+            }
+            ptr<buffer> resp_buf(buffer::alloc(RPC_RESP_HEADER_SIZE));
+            aa::read( ssl_enabled_, ssl_socket_, socket_,
+                      asio::buffer(resp_buf->data(), resp_buf->size()),
+                      std::bind( &asio_rpc_client::response_read,
+                                 self,
+                                 req,
+                                 when_done,
+                                 resp_buf,
+                                 std::placeholders::_1,
+                                 std::placeholders::_2 ) );
+        } catch (const std::exception& e) {
+            receive_timer_.cancel();
+            clear_busy_flag_if_set(true);
+            std::string err_msg = setup_exception_message("response read setup", req, e);
+            handle_error(req, err_msg, when_done);
+        } catch (...) {
+            receive_timer_.cancel();
+            clear_busy_flag_if_set(true);
+            std::string err_msg = setup_unknown_exception_message("response read setup", req);
+            handle_error(req, err_msg, when_done);
         }
-        ptr<buffer> resp_buf(buffer::alloc(RPC_RESP_HEADER_SIZE));
-        aa::read( ssl_enabled_, ssl_socket_, socket_,
-                  asio::buffer(resp_buf->data(), resp_buf->size()),
-                  std::bind( &asio_rpc_client::response_read,
-                             self,
-                             req,
-                             when_done,
-                             resp_buf,
-                             std::placeholders::_1,
-                             std::placeholders::_2 ) );
     }
 
     void response_read(ptr<req_msg>& req,
@@ -1993,6 +2158,7 @@ private:
         ptr<asio_rpc_client> self(this->shared_from_this());
         if (err) {
             receive_timer_.cancel();
+            clear_busy_flag_if_set(true);
             std::string err_msg = sstrfmt( "failed to read response to peer %d, %s:%s, "
                                            "error %d, %s" )
                                            .fmt( req->get_dst(), host_.c_str(),
@@ -2002,73 +2168,90 @@ private:
             return;
         }
 
-        buffer_serializer bs(resp_buf);
-        uint32_t crc_local = crc32_8( resp_buf->data_begin(),
-                                      RPC_RESP_HEADER_SIZE - CRC_FLAGS_LEN,
-                                      0 );
-        bs.pos(RPC_RESP_HEADER_SIZE - CRC_FLAGS_LEN);
-        uint64_t flags_and_crc = bs.get_u64();
-        uint32_t crc_buf = flags_and_crc & (uint32_t)0xffffffff;
-        uint32_t flags = (flags_and_crc >> 32);
+        ptr<resp_msg> rsp;
+        std::string completion_error_msg;
+        try {
+            buffer_serializer bs(resp_buf);
+            uint32_t crc_local = crc32_8( resp_buf->data_begin(),
+                                          RPC_RESP_HEADER_SIZE - CRC_FLAGS_LEN,
+                                          0 );
+            bs.pos(RPC_RESP_HEADER_SIZE - CRC_FLAGS_LEN);
+            uint64_t flags_and_crc = bs.get_u64();
+            uint32_t crc_buf = flags_and_crc & (uint32_t)0xffffffff;
+            uint32_t flags = (flags_and_crc >> 32);
 
-        if (crc_local != crc_buf) {
+            if (crc_local != crc_buf) {
+                completion_error_msg =
+                    sstrfmt( "CRC mismatch in response from "
+                             "peer %d, %s:%s, "
+                             "local calculation %x, from buffer %x")
+                             .fmt( req->get_dst(), host_.c_str(),
+                                   port_.c_str(), crc_local, crc_buf );
+            } else {
+                bs.pos(1);
+                byte msg_type_val = bs.get_u8();
+                int32 src = bs.get_i32();
+                int32 dst = bs.get_i32();
+                ulong term = bs.get_u64();
+                ulong nxt_idx = bs.get_u64();
+                byte accepted_val = bs.get_u8();
+                int32 carried_data_size = bs.get_i32();
+                rsp = cs_new<resp_msg>
+                      ( term, (msg_type)msg_type_val, src, dst,
+                        nxt_idx, accepted_val == 1 );
+
+                if ( !(flags & INCLUDE_META) &&
+                     impl_->get_options().read_resp_meta_ &&
+                     impl_->get_options().invoke_resp_cb_on_empty_meta_ ) {
+                    // If callback is given, but meta is empty, and
+                    // the "always invoke" flag is set, invoke it.
+                    handle_custom_resp_meta
+                    ( req, rsp, std::string(), completion_error_msg );
+                }
+
+                if (completion_error_msg.empty() && (flags & MARK_DOWN)) {
+                    // Mark down flag is set in the response.
+                    rsp->set_extra_flags(rsp->get_extra_flags() | resp_msg::SELF_MARK_DOWN);
+                }
+
+                if (completion_error_msg.empty() && carried_data_size) {
+                    ptr<buffer> ctx_buf = buffer::alloc(carried_data_size);
+                    aa::read( ssl_enabled_, ssl_socket_, socket_,
+                              asio::buffer(ctx_buf->data(), carried_data_size),
+                              std::bind( &asio_rpc_client::ctx_read,
+                                         self,
+                                         req,
+                                         rsp,
+                                         when_done,
+                                         ctx_buf,
+                                         flags,
+                                         std::placeholders::_1,
+                                         std::placeholders::_2 ) );
+                    return;
+                }
+            }
+        } catch (const std::exception& e) {
             receive_timer_.cancel();
-            std::string err_msg = sstrfmt( "CRC mismatch in response from "
-                                           "peer %d, %s:%s, "
-                                           "local calculation %x, from buffer %x")
-                                           .fmt( req->get_dst(), host_.c_str(),
-                                                 port_.c_str(), crc_local, crc_buf );
+            clear_busy_flag_if_set(true);
+            std::string err_msg = setup_exception_message("response read completion", req, e);
+            handle_error(req, err_msg, when_done);
+            return;
+        } catch (...) {
+            receive_timer_.cancel();
+            clear_busy_flag_if_set(true);
+            std::string err_msg = setup_unknown_exception_message("response read completion", req);
             handle_error(req, err_msg, when_done);
             return;
         }
 
-        bs.pos(1);
-        byte msg_type_val = bs.get_u8();
-        int32 src = bs.get_i32();
-        int32 dst = bs.get_i32();
-        ulong term = bs.get_u64();
-        ulong nxt_idx = bs.get_u64();
-        byte accepted_val = bs.get_u8();
-        int32 carried_data_size = bs.get_i32();
-        ptr<resp_msg> rsp
-            ( cs_new<resp_msg>
-              ( term, (msg_type)msg_type_val, src, dst,
-                nxt_idx, accepted_val == 1 ) );
-
-        if ( !(flags & INCLUDE_META) &&
-             impl_->get_options().read_resp_meta_ &&
-             impl_->get_options().invoke_resp_cb_on_empty_meta_ ) {
-            // If callback is given, but meta is empty, and
-            // the "always invoke" flag is set, invoke it.
-            bool meta_ok = handle_custom_resp_meta
-                           ( req, rsp, when_done, std::string() );
-            if (!meta_ok) {
-                receive_timer_.cancel();
-                return;
-            }
+        if (!completion_error_msg.empty()) {
+            receive_timer_.cancel();
+            clear_busy_flag_if_set(true);
+            handle_error(req, completion_error_msg, when_done);
+            return;
         }
 
-        if (flags & MARK_DOWN) {
-            // Mark down flag is set in the response.
-            rsp->set_extra_flags(rsp->get_extra_flags() | resp_msg::SELF_MARK_DOWN);
-        }
-
-        if (carried_data_size) {
-            ptr<buffer> ctx_buf = buffer::alloc(carried_data_size);
-            aa::read( ssl_enabled_, ssl_socket_, socket_,
-                      asio::buffer(ctx_buf->data(), carried_data_size),
-                      std::bind( &asio_rpc_client::ctx_read,
-                                 self,
-                                 req,
-                                 rsp,
-                                 when_done,
-                                 ctx_buf,
-                                 flags,
-                                 std::placeholders::_1,
-                                 std::placeholders::_2 ) );
-        } else {
-            post_read(req, rsp, when_done);
-        }
+        post_read(req, rsp, when_done);
     }
 
     void ctx_read(ptr<req_msg>& req,
@@ -2081,6 +2264,7 @@ private:
     {
         if (err) {
             receive_timer_.cancel();
+            clear_busy_flag_if_set(true);
             std::string err_msg = sstrfmt( "failed to read response context "
                                            "from peer %d, %s:%s, error %d, %s" )
                                            .fmt( req->get_dst(), host_.c_str(),
@@ -2090,74 +2274,92 @@ private:
             return;
         }
 
-        if ( !(flags & INCLUDE_META) &&
-             !(flags & INCLUDE_HINT) &&
-	     !(flags & INCLUDE_RESULT_CODE)) {
-            // Neither meta nor hint nor result code exists,
-            // just use the buffer as it is for ctx.
-            ctx_buf->pos(0);
-            rsp->set_ctx(ctx_buf);
+        std::string completion_error_msg;
+        try {
+            if ( !(flags & INCLUDE_META) &&
+                 !(flags & INCLUDE_HINT) &&
+                 !(flags & INCLUDE_RESULT_CODE)) {
+                // Neither meta nor hint nor result code exists,
+                // just use the buffer as it is for ctx.
+                ctx_buf->pos(0);
+                rsp->set_ctx(ctx_buf);
+            }
+            else
+            {
+                // Otherwise: buffer contains composite data.
+                buffer_serializer bs(ctx_buf);
+                int remaining_len = ctx_buf->size();
 
-            post_read(req, rsp, when_done);
+                // 1) Custom meta.
+                if (flags & INCLUDE_META) {
+                    size_t resp_meta_len = 0;
+                    void* resp_meta_raw = bs.get_bytes(resp_meta_len);
+
+                    // If callback is given, verify meta
+                    // (if meta is empty, invoke callback according to the flag).
+                    if ( impl_->get_options().read_resp_meta_ &&
+                         ( resp_meta_len ||
+                           impl_->get_options().invoke_resp_cb_on_empty_meta_ ) ) {
+
+                        handle_custom_resp_meta
+                        ( req, rsp,
+                          std::string( (const char*)resp_meta_raw,
+                                       resp_meta_len ),
+                          completion_error_msg );
+                    }
+                    remaining_len -= sizeof(int32) + resp_meta_len;
+                }
+
+                // 2) Hint.
+                if (completion_error_msg.empty() && (flags & INCLUDE_HINT)) {
+                    size_t hint_len = 0;
+                    uint16_t hint_version = bs.get_u16();
+                    (void)hint_version;
+                    hint_len = bs.get_u16();
+                    rsp->set_next_batch_size_hint_in_bytes(bs.get_i64());
+                    remaining_len -= sizeof(uint16_t) * 2 + hint_len;
+                }
+
+                // 3) Context.
+                assert(remaining_len >= 0);
+                size_t ctx_len = remaining_len;
+                if (completion_error_msg.empty() && (flags & INCLUDE_RESULT_CODE)) {
+                    ctx_len -= sizeof(int32_t);
+                }
+                if (completion_error_msg.empty() && ctx_len) {
+                    // It has context, read it.
+                    ptr<buffer> actual_ctx = buffer::alloc(ctx_len);
+                    bs.get_buffer(actual_ctx);
+                    rsp->set_ctx(actual_ctx);
+                    remaining_len -= ctx_len;
+                }
+
+                // 4) Result code
+                if (completion_error_msg.empty() && (flags & INCLUDE_RESULT_CODE)) {
+                    assert((size_t)remaining_len >= sizeof(int32_t));
+                    cmd_result_code res = static_cast<cmd_result_code>(bs.get_i32());
+                    rsp->set_result_code(res);
+                }
+            }
+        } catch (const std::exception& e) {
+            receive_timer_.cancel();
+            clear_busy_flag_if_set(true);
+            std::string err_msg = setup_exception_message("context read completion", req, e);
+            handle_error(req, err_msg, when_done);
+            return;
+        } catch (...) {
+            receive_timer_.cancel();
+            clear_busy_flag_if_set(true);
+            std::string err_msg = setup_unknown_exception_message("context read completion", req);
+            handle_error(req, err_msg, when_done);
             return;
         }
 
-        // Otherwise: buffer contains composite data.
-        buffer_serializer bs(ctx_buf);
-        int remaining_len = ctx_buf->size();
-
-        // 1) Custom meta.
-        if (flags & INCLUDE_META) {
-            size_t resp_meta_len = 0;
-            void* resp_meta_raw = bs.get_bytes(resp_meta_len);
-
-            // If callback is given, verify meta
-            // (if meta is empty, invoke callback according to the flag).
-            if ( impl_->get_options().read_resp_meta_ &&
-                 ( resp_meta_len ||
-                   impl_->get_options().invoke_resp_cb_on_empty_meta_ ) ) {
-
-                bool meta_ok = handle_custom_resp_meta
-                               ( req, rsp, when_done,
-                                 std::string( (const char*)resp_meta_raw,
-                                              resp_meta_len) );
-                if (!meta_ok) {
-                    receive_timer_.cancel();
-                    return;
-                }
-            }
-            remaining_len -= sizeof(int32) + resp_meta_len;
-        }
-
-        // 2) Hint.
-        if (flags & INCLUDE_HINT) {
-            size_t hint_len = 0;
-            uint16_t hint_version = bs.get_u16();
-            (void)hint_version;
-            hint_len = bs.get_u16();
-            rsp->set_next_batch_size_hint_in_bytes(bs.get_i64());
-            remaining_len -= sizeof(uint16_t) * 2 + hint_len;
-        }
-
-        // 3) Context.
-        assert(remaining_len >= 0);
-        size_t ctx_len = remaining_len;
-        if (flags & INCLUDE_RESULT_CODE) {
-            ctx_len -= sizeof(int32_t);
-        }
-        if (ctx_len) {
-            // It has context, read it.
-            ptr<buffer> actual_ctx = buffer::alloc(ctx_len);
-            bs.get_buffer(actual_ctx);
-            rsp->set_ctx(actual_ctx);
-            remaining_len -= ctx_len;
-        }
-
-        // 4) Result code
-        if (flags & INCLUDE_RESULT_CODE) {
-            assert((size_t)remaining_len >= sizeof(int32_t));
-            cmd_result_code res = static_cast<cmd_result_code>(bs.get_i32());
-            rsp->set_result_code(res);
+        if (!completion_error_msg.empty()) {
+            receive_timer_.cancel();
+            clear_busy_flag_if_set(true);
+            handle_error(req, completion_error_msg, when_done);
+            return;
         }
 
         post_read(req, rsp, when_done);
@@ -2165,19 +2367,18 @@ private:
 
     bool handle_custom_resp_meta(ptr<req_msg>& req,
                                  ptr<resp_msg>& rsp,
-                                 rpc_handler& when_done,
-                                 const std::string& meta_str)
+                                 const std::string& meta_str,
+                                 std::string& err_msg)
     {
         bool meta_ok = impl_->get_options().read_resp_meta_
                        ( req_to_params(req.get(), rsp.get()), meta_str );
 
         if (!meta_ok) {
             // Callback function returns false, should return failure.
-            std::string err_msg = sstrfmt( "response meta verification failed: "
-                                           "from peer %d, %s:%s")
-                                           .fmt( req->get_dst(), host_.c_str(),
-                                                 port_.c_str() );
-            handle_error(req, err_msg, when_done);
+            err_msg = sstrfmt( "response meta verification failed: "
+                               "from peer %d, %s:%s")
+                               .fmt( req->get_dst(), host_.c_str(),
+                                     port_.c_str() );
             return false;
         }
         return true;

--- a/src/handle_vote.cxx
+++ b/src/handle_vote.cxx
@@ -33,6 +33,24 @@ limitations under the License.
 
 namespace nuraft {
 
+namespace {
+
+uint64_t get_election_rpc_timeout_ms(const raft_params& params, int32 response_limit) {
+    if (params.election_timeout_upper_bound_ > 0) {
+        return static_cast<uint64_t>(params.election_timeout_upper_bound_);
+    }
+    if (params.election_timeout_lower_bound_ > 0) {
+        return static_cast<uint64_t>(params.election_timeout_lower_bound_);
+    }
+    if (params.heart_beat_interval_ > 0 && response_limit > 0) {
+        return static_cast<uint64_t>(params.heart_beat_interval_) *
+               static_cast<uint64_t>(response_limit);
+    }
+    return 0;
+}
+
+} // namespace
+
 bool raft_server::check_cond_for_zp_election() {
     ptr<raft_params> params = ctx_->get_params();
     if ( params->allow_temporary_zero_priority_leader_ &&
@@ -47,6 +65,20 @@ bool raft_server::check_cond_for_zp_election() {
 
 void raft_server::request_prevote() {
     ptr<raft_params> params = ctx_->get_params();
+    const int32 response_limit = raft_server::raft_limits_.response_limit_.load();
+    const uint64_t election_rpc_timeout_ms =
+        get_election_rpc_timeout_ms(*params, response_limit);
+    if (!election_rpc_timeout_ms) {
+        p_er("cannot send election RPC with disabled timeout: "
+             "election_timeout_upper_bound %d, election_timeout_lower_bound %d, "
+             "heart_beat_interval %d, response_limit %d",
+             params->election_timeout_upper_bound_,
+             params->election_timeout_lower_bound_,
+             params->heart_beat_interval_,
+             response_limit);
+        return;
+    }
+
     ptr<cluster_config> c_config = get_config();
     for (peer_itor it = peers_.begin(); it != peers_.end(); ++it) {
         ptr<peer> pp = it->second;
@@ -165,7 +197,7 @@ void raft_server::request_prevote() {
                             log_store_->next_slot() - 1,
                             quick_commit_index_.load() ) );
         if (pp->make_busy()) {
-            pp->send_req(pp, req, resp_handler_);
+            pp->send_req(pp, req, resp_handler_, false, election_rpc_timeout_ms);
         } else {
             pre_vote_.connection_busy_++;
             p_wn("failed to send prevote request: peer %d (%s) is busy, count %d",
@@ -197,7 +229,8 @@ void raft_server::request_prevote() {
 }
 
 void raft_server::initiate_vote(bool force_vote) {
-    int grace_period = ctx_->get_params()->grace_period_of_lagging_state_machine_;
+    ptr<raft_params> params = ctx_->get_params();
+    int grace_period = params->grace_period_of_lagging_state_machine_;
     ulong cur_term = state_->get_term();
     if ( !force_vote &&
          grace_period &&
@@ -235,6 +268,20 @@ void raft_server::initiate_vote(bool force_vote) {
          check_cond_for_zp_election() ||
          ( get_quorum_for_election() == 0 &&
            my_priority_ > 0 ) ) {
+        const int32 response_limit = raft_server::raft_limits_.response_limit_.load();
+        const uint64_t election_rpc_timeout_ms =
+            get_election_rpc_timeout_ms(*params, response_limit);
+        if (!election_rpc_timeout_ms) {
+            p_er("cannot send election RPC with disabled timeout: "
+                 "election_timeout_upper_bound %d, election_timeout_lower_bound %d, "
+                 "heart_beat_interval %d, response_limit %d",
+                 params->election_timeout_upper_bound_,
+                 params->election_timeout_lower_bound_,
+                 params->heart_beat_interval_,
+                 response_limit);
+            return;
+        }
+
         // Request vote when
         //  1) my priority satisfies the target, OR
         //  2) I'm the only node in the group.
@@ -247,7 +294,7 @@ void raft_server::initiate_vote(bool force_vote) {
         election_completed_ = false;
         // NOTE: Following `request_vote` will call `save_state()`,
         //       hence we don't call it here even though `state_` changes.
-        request_vote(force_vote);
+        request_vote(force_vote, election_rpc_timeout_ms);
     }
 
     if (role_ != srv_role::leader) {
@@ -256,7 +303,7 @@ void raft_server::initiate_vote(bool force_vote) {
     }
 }
 
-void raft_server::request_vote(bool force_vote) {
+void raft_server::request_vote(bool force_vote, uint64_t election_rpc_timeout_ms) {
     state_->set_voted_for(id_);
     ctx_->state_mgr_->save_state(*state_);
     votes_granted_ += 1;
@@ -305,7 +352,7 @@ void raft_server::request_vote(bool force_vote) {
               it->second->get_id(),
               state_->get_term() );
         if (pp->make_busy()) {
-            pp->send_req(pp, req, resp_handler_);
+            pp->send_req(pp, req, resp_handler_, false, election_rpc_timeout_ms);
         } else {
             p_wn("failed to send vote request: peer %d (%s) is busy",
                  pp->get_id(), pp->get_endpoint().c_str());
@@ -552,4 +599,3 @@ void raft_server::handle_prevote_resp(resp_msg& resp) {
 }
 
 } // namespace nuraft;
-

--- a/src/peer.cxx
+++ b/src/peer.cxx
@@ -22,8 +22,11 @@ limitations under the License.
 
 #include "debugging_options.hxx"
 #include "raft_server.hxx"
+#include "strfmt.hxx"
 #include "tracer.hxx"
 
+#include <atomic>
+#include <memory>
 #include <unordered_set>
 
 namespace nuraft {
@@ -31,11 +34,13 @@ namespace nuraft {
 void peer::send_req( ptr<peer> myself,
                      ptr<req_msg>& req,
                      rpc_handler& handler,
-                     bool streaming )
+                     bool streaming,
+                     uint64_t send_timeout_ms )
 {
     if (abandoned_) {
         p_er("peer %d has been shut down, cannot send request",
              get_config().get_id());
+        set_free();
         return;
     }
 
@@ -66,20 +71,68 @@ void peer::send_req( ptr<peer> myself,
         }
     }
 
-    rpc_handler h = (rpc_handler)std::bind
-                    ( &peer::handle_rpc_result,
-                      this,
-                      myself,
-                      rpc_local->get_id(),
-                      req,
-                      pending,
-                      streaming,
-                      req_size_bytes,
-                      std::placeholders::_1,
-                      std::placeholders::_2 );
-    if (rpc_local) {
-        myself->bytes_in_flight_add(req_size_bytes);
-        rpc_local->send(req, h);
+    uint64_t rpc_client_id = rpc_local->get_id();
+    auto rpc_callback_invoked = std::make_shared<std::atomic<bool>>(false);
+    rpc_handler h =
+        [this,
+         myself,
+         rpc_client_id,
+         req,
+         pending,
+         streaming,
+         req_size_bytes,
+         rpc_callback_invoked]
+        (ptr<resp_msg>& resp, ptr<rpc_exception>& err) mutable
+        {
+            rpc_callback_invoked->store(true, std::memory_order_relaxed);
+            handle_rpc_result(myself,
+                              rpc_client_id,
+                              req,
+                              pending,
+                              streaming,
+                              req_size_bytes,
+                              resp,
+                              err);
+        };
+    myself->bytes_in_flight_add(req_size_bytes);
+    try {
+        rpc_local->send(req, h, send_timeout_ms);
+    } catch (const std::exception& e) {
+        if (rpc_callback_invoked->load(std::memory_order_relaxed)) {
+            throw;
+        }
+
+        std::string err_msg =
+            lstrfmt("synchronous exception from rpc_client::send to peer %d: %s")
+                .fmt(req->get_dst(), e.what());
+        ptr<resp_msg> no_resp;
+        ptr<rpc_exception> err = cs_new<rpc_exception>(err_msg, req);
+        handle_rpc_result(myself,
+                          rpc_client_id,
+                          req,
+                          pending,
+                          streaming,
+                          req_size_bytes,
+                          no_resp,
+                          err);
+    } catch (...) {
+        if (rpc_callback_invoked->load(std::memory_order_relaxed)) {
+            throw;
+        }
+
+        std::string err_msg =
+            lstrfmt("synchronous unknown exception from rpc_client::send to peer %d")
+                .fmt(req->get_dst());
+        ptr<resp_msg> no_resp;
+        ptr<rpc_exception> err = cs_new<rpc_exception>(err_msg, req);
+        handle_rpc_result(myself,
+                          rpc_client_id,
+                          req,
+                          pending,
+                          streaming,
+                          req_size_bytes,
+                          no_resp,
+                          err);
     }
 }
 
@@ -152,12 +205,15 @@ void peer::handle_rpc_result( ptr<peer> myself,
             auto_lock(lock_);
             resume_hb_speed();
         }
-        ptr<rpc_exception> no_except;
-        resp->set_peer(myself);
-        pending_result->set_result(resp, no_except);
 
         reconn_backoff_.reset();
         reconn_backoff_.set_duration_ms(1);
+
+        ptr<rpc_exception> no_except;
+        resp->set_peer(myself);
+        // `set_result` invokes user handlers synchronously, so all peer
+        // lifecycle cleanup must stay before this call.
+        pending_result->set_result(resp, no_except);
 
     } else {
         // Failed.
@@ -169,8 +225,6 @@ void peer::handle_rpc_result( ptr<peer> myself,
             auto_lock(lock_);
             slow_down_hb();
         }
-        ptr<resp_msg> no_resp;
-        pending_result->set_result(no_resp, err);
 
         // Destroy this connection, we MUST NOT re-use existing socket.
         // Next append operation will create a new one.
@@ -217,6 +271,11 @@ void peer::handle_rpc_result( ptr<peer> myself,
                 }
             }
         }
+
+        ptr<resp_msg> no_resp;
+        // `set_result` invokes user handlers synchronously, so all peer
+        // lifecycle cleanup must stay before this call.
+        pending_result->set_result(no_resp, err);
     }
 }
 
@@ -327,4 +386,3 @@ void peer::reopen(context& ctx, timer_task<int32>::executor& hb_exec) {
 }
 
 } // namespace nuraft;
-

--- a/tests/asio/asio_service_test.cxx
+++ b/tests/asio/asio_service_test.cxx
@@ -16,6 +16,7 @@ limitations under the License.
 **************************************************************************/
 
 #include "buffer_serializer.hxx"
+#include "crc32.hxx"
 #include "debugging_options.hxx"
 #include "in_memory_log_store.hxx"
 #include "raft_package_asio.hxx"
@@ -33,7 +34,13 @@ limitations under the License.
     using asio_error_code = asio::error_code;
 #endif
 
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <system_error>
 #include <unordered_map>
+#include <vector>
 
 #include <stdio.h>
 
@@ -723,6 +730,483 @@ int auto_forwarding_timeout_test() {
 
     SimpleLogger::shutdown();
 
+    return 0;
+}
+
+int rpc_response_timeout_invokes_callback_once_test(bool streaming_mode) {
+    reset_log_files();
+
+    asio_service::options opt;
+    opt.thread_pool_size_ = 1;
+    opt.streaming_mode_ = streaming_mode;
+    asio_service svc(opt);
+
+    asio::io_context server_io;
+    asio::ip::tcp::acceptor acceptor(
+        server_io,
+        asio::ip::tcp::endpoint(asio::ip::address_v4::loopback(), 0));
+    asio::ip::tcp::endpoint server_endpoint = acceptor.local_endpoint();
+    uint16_t port = server_endpoint.port();
+
+    EventAwaiter accepted_ea;
+    EventAwaiter stop_server_ea;
+    std::atomic<bool> accept_ready(false);
+    std::shared_ptr<asio::ip::tcp::socket> accepted_socket;
+    std::mutex accepted_socket_lock;
+    std::thread server_thread([&]() {
+        auto socket = std::make_shared<asio::ip::tcp::socket>(server_io);
+        asio_error_code err;
+        acceptor.accept(*socket, err);
+        if (!err) {
+            {
+                std::lock_guard<std::mutex> guard(accepted_socket_lock);
+                accepted_socket = socket;
+            }
+            accept_ready = true;
+            accepted_ea.invoke();
+            stop_server_ea.wait();
+            socket->close(err);
+        }
+    });
+
+    struct ServerThreadGuard {
+        EventAwaiter& stop_server_ea_;
+        asio::io_context& server_io_;
+        asio::ip::tcp::acceptor& acceptor_;
+        asio::ip::tcp::endpoint server_endpoint_;
+        std::shared_ptr<asio::ip::tcp::socket>& accepted_socket_;
+        std::mutex& accepted_socket_lock_;
+        std::atomic<bool>& accept_ready_;
+        std::thread& server_thread_;
+
+        ~ServerThreadGuard() {
+            stop_server_ea_.invoke();
+
+            asio_error_code err;
+            if (!accept_ready_.load()) {
+                asio::ip::tcp::socket unblock_socket(server_io_);
+                unblock_socket.connect(server_endpoint_, err);
+            }
+
+            std::shared_ptr<asio::ip::tcp::socket> socket;
+            {
+                std::lock_guard<std::mutex> guard(accepted_socket_lock_);
+                socket = accepted_socket_;
+            }
+
+            if (socket) {
+                socket->close(err);
+            }
+            acceptor_.close(err);
+            if (server_thread_.joinable()) {
+                server_thread_.join();
+            }
+        }
+    };
+    ServerThreadGuard server_thread_guard{
+        stop_server_ea,
+        server_io,
+        acceptor,
+        server_endpoint,
+        accepted_socket,
+        accepted_socket_lock,
+        accept_ready,
+        server_thread};
+
+    ptr<rpc_client> client =
+        svc.create_client("127.0.0.1:" + std::to_string(port));
+    CHK_NONNULL(client.get());
+
+    ptr<req_msg> req = cs_new<req_msg>(1,
+                                       msg_type::append_entries_request,
+                                       1,
+                                       2,
+                                       0,
+                                       0,
+                                       0);
+
+    EventAwaiter first_callback_ea;
+    EventAwaiter duplicate_callback_ea;
+    std::atomic<int> callback_count(0);
+    std::atomic<bool> got_error(false);
+    std::atomic<bool> got_empty_resp(false);
+
+    rpc_handler handler = [&](ptr<resp_msg>& resp, ptr<rpc_exception>& err) {
+        int count = callback_count.fetch_add(1) + 1;
+        got_error = (err != nullptr);
+        got_empty_resp = (resp == nullptr);
+        if (count == 1) {
+            first_callback_ea.invoke();
+        } else {
+            duplicate_callback_ea.invoke();
+        }
+    };
+
+    client->send(req, handler, 50);
+    accepted_ea.wait_ms(3000);
+    CHK_TRUE( accept_ready.load() );
+
+    first_callback_ea.wait_ms(3000);
+    CHK_EQ( 1, callback_count.load() );
+    CHK_TRUE( got_error.load() );
+    CHK_TRUE( got_empty_resp.load() );
+    CHK_TRUE( client->is_abandoned() );
+
+    duplicate_callback_ea.wait_ms(300);
+    CHK_EQ( 1, callback_count.load() );
+
+    svc.stop();
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
+int rpc_response_meta_rejection_throwing_callback_test() {
+    reset_log_files();
+
+    asio_service::options opt;
+    opt.thread_pool_size_ = 1;
+    opt.streaming_mode_ = false;
+    opt.invoke_resp_cb_on_empty_meta_ = true;
+    opt.read_resp_meta_ =
+        [](const asio_service::meta_cb_params&, const std::string&) -> bool {
+            return false;
+        };
+    asio_service svc(opt);
+
+    asio::io_context server_io;
+    asio::ip::tcp::acceptor acceptor(
+        server_io,
+        asio::ip::tcp::endpoint(asio::ip::address_v4::loopback(), 0));
+    asio::ip::tcp::endpoint server_endpoint = acceptor.local_endpoint();
+    uint16_t port = server_endpoint.port();
+
+    EventAwaiter accepted_ea;
+    EventAwaiter stop_server_ea;
+    std::atomic<bool> accept_ready(false);
+    std::shared_ptr<asio::ip::tcp::socket> accepted_socket;
+    std::mutex accepted_socket_lock;
+    std::thread server_thread([&]() {
+        auto socket = std::make_shared<asio::ip::tcp::socket>(server_io);
+        asio_error_code err;
+        acceptor.accept(*socket, err);
+        if (!err) {
+            {
+                std::lock_guard<std::mutex> guard(accepted_socket_lock);
+                accepted_socket = socket;
+            }
+            accept_ready = true;
+            accepted_ea.invoke();
+
+            const size_t rpc_req_header_size = 4 * 3 + 8 * 5 + 1 * 2;
+            std::vector<byte> req_header(rpc_req_header_size);
+            asio::read(*socket, asio::buffer(req_header), err);
+
+            if (!err) {
+                const size_t rpc_resp_header_size = 4 * 3 + 8 * 3 + 1 * 3;
+                const size_t crc_flags_len = 8;
+                ptr<buffer> resp_buf = buffer::alloc(rpc_resp_header_size);
+                buffer_serializer bs(resp_buf);
+                bs.put_u8(0x1);
+                bs.put_u8(static_cast<byte>(msg_type::append_entries_response));
+                bs.put_i32(2);
+                bs.put_i32(1);
+                bs.put_u64(1);
+                bs.put_u64(1);
+                bs.put_u8(1);
+                bs.put_i32(0);
+
+                uint32_t crc_val = crc32_8(resp_buf->data_begin(),
+                                           rpc_resp_header_size - crc_flags_len,
+                                           0);
+                bs.put_u64(crc_val);
+
+                asio::write(*socket,
+                            asio::buffer(resp_buf->data_begin(), resp_buf->size()),
+                            err);
+            }
+
+            stop_server_ea.wait();
+            socket->close(err);
+        }
+    });
+
+    struct ServerThreadGuard {
+        EventAwaiter& stop_server_ea_;
+        asio::io_context& server_io_;
+        asio::ip::tcp::acceptor& acceptor_;
+        asio::ip::tcp::endpoint server_endpoint_;
+        std::shared_ptr<asio::ip::tcp::socket>& accepted_socket_;
+        std::mutex& accepted_socket_lock_;
+        std::atomic<bool>& accept_ready_;
+        std::thread& server_thread_;
+
+        ~ServerThreadGuard() {
+            stop_server_ea_.invoke();
+
+            asio_error_code err;
+            if (!accept_ready_.load()) {
+                asio::ip::tcp::socket unblock_socket(server_io_);
+                unblock_socket.connect(server_endpoint_, err);
+            }
+
+            std::shared_ptr<asio::ip::tcp::socket> socket;
+            {
+                std::lock_guard<std::mutex> guard(accepted_socket_lock_);
+                socket = accepted_socket_;
+            }
+
+            if (socket) {
+                socket->close(err);
+            }
+            acceptor_.close(err);
+            if (server_thread_.joinable()) {
+                server_thread_.join();
+            }
+        }
+    };
+    ServerThreadGuard server_thread_guard{
+        stop_server_ea,
+        server_io,
+        acceptor,
+        server_endpoint,
+        accepted_socket,
+        accepted_socket_lock,
+        accept_ready,
+        server_thread};
+
+    ptr<rpc_client> client =
+        svc.create_client("127.0.0.1:" + std::to_string(port));
+    CHK_NONNULL(client.get());
+
+    ptr<req_msg> req = cs_new<req_msg>(1,
+                                       msg_type::append_entries_request,
+                                       1,
+                                       2,
+                                       0,
+                                       0,
+                                       0);
+
+    EventAwaiter first_callback_ea;
+    EventAwaiter duplicate_callback_ea;
+    std::atomic<int> callback_count(0);
+    std::atomic<bool> got_error(false);
+
+    rpc_handler handler = [&](ptr<resp_msg>&, ptr<rpc_exception>& err) {
+        int count = callback_count.fetch_add(1) + 1;
+        got_error = (err != nullptr);
+        if (count == 1) {
+            first_callback_ea.invoke();
+            throw std::runtime_error("metadata rejection callback exception");
+        }
+        duplicate_callback_ea.invoke();
+    };
+
+    client->send(req, handler, 0);
+    accepted_ea.wait_ms(3000);
+    CHK_TRUE( accept_ready.load() );
+
+    first_callback_ea.wait_ms(3000);
+    CHK_EQ( 1, callback_count.load() );
+    CHK_TRUE( got_error.load() );
+    CHK_TRUE( client->is_abandoned() );
+
+    duplicate_callback_ea.wait_ms(300);
+    CHK_EQ( 1, callback_count.load() );
+
+    svc.stop();
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
+int rpc_custom_resolver_error_throwing_callback_test() {
+    reset_log_files();
+
+    asio_service::options opt;
+    opt.thread_pool_size_ = 1;
+    opt.streaming_mode_ = false;
+    opt.custom_resolver_ =
+        [](const std::string&,
+           const std::string&,
+           asio_service_custom_resolver_response when_done) {
+            when_done(std::string(),
+                      std::string(),
+                      std::make_error_code(std::errc::host_unreachable));
+        };
+    asio_service svc(opt);
+
+    ptr<rpc_client> client = svc.create_client("unresolved-host:1");
+    CHK_NONNULL(client.get());
+
+    ptr<req_msg> req = cs_new<req_msg>(1,
+                                       msg_type::append_entries_request,
+                                       1,
+                                       2,
+                                       0,
+                                       0,
+                                       0);
+
+    EventAwaiter first_callback_ea;
+    EventAwaiter duplicate_callback_ea;
+    std::atomic<int> callback_count(0);
+    std::atomic<bool> got_error(false);
+
+    rpc_handler handler = [&](ptr<resp_msg>&, ptr<rpc_exception>& err) {
+        int count = callback_count.fetch_add(1) + 1;
+        got_error = (err != nullptr);
+        if (count == 1) {
+            first_callback_ea.invoke();
+            throw std::runtime_error("custom resolver callback exception");
+        }
+        duplicate_callback_ea.invoke();
+    };
+
+    try {
+        client->send(req, handler, 0);
+    } catch (const std::runtime_error&) {
+    }
+
+    first_callback_ea.wait_ms(3000);
+    CHK_EQ( 1, callback_count.load() );
+    CHK_TRUE( got_error.load() );
+    CHK_TRUE( client->is_abandoned() );
+
+    duplicate_callback_ea.wait_ms(300);
+    CHK_EQ( 1, callback_count.load() );
+
+    svc.stop();
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+
+int rpc_write_req_meta_exception_throwing_callback_test() {
+    reset_log_files();
+
+    asio_service::options opt;
+    opt.thread_pool_size_ = 1;
+    opt.streaming_mode_ = false;
+    opt.write_req_meta_ =
+        [](const asio_service::meta_cb_params&) -> std::string {
+            throw std::runtime_error("write request metadata exception");
+        };
+    asio_service svc(opt);
+
+    asio::io_context server_io;
+    asio::ip::tcp::acceptor acceptor(
+        server_io,
+        asio::ip::tcp::endpoint(asio::ip::address_v4::loopback(), 0));
+    asio::ip::tcp::endpoint server_endpoint = acceptor.local_endpoint();
+    uint16_t port = server_endpoint.port();
+
+    EventAwaiter accepted_ea;
+    EventAwaiter stop_server_ea;
+    std::atomic<bool> accept_ready(false);
+    std::shared_ptr<asio::ip::tcp::socket> accepted_socket;
+    std::mutex accepted_socket_lock;
+    std::thread server_thread([&]() {
+        auto socket = std::make_shared<asio::ip::tcp::socket>(server_io);
+        asio_error_code err;
+        acceptor.accept(*socket, err);
+        if (!err) {
+            {
+                std::lock_guard<std::mutex> guard(accepted_socket_lock);
+                accepted_socket = socket;
+            }
+            accept_ready = true;
+            accepted_ea.invoke();
+            stop_server_ea.wait();
+            socket->close(err);
+        }
+    });
+
+    struct ServerThreadGuard {
+        EventAwaiter& stop_server_ea_;
+        asio::io_context& server_io_;
+        asio::ip::tcp::acceptor& acceptor_;
+        asio::ip::tcp::endpoint server_endpoint_;
+        std::shared_ptr<asio::ip::tcp::socket>& accepted_socket_;
+        std::mutex& accepted_socket_lock_;
+        std::atomic<bool>& accept_ready_;
+        std::thread& server_thread_;
+
+        ~ServerThreadGuard() {
+            stop_server_ea_.invoke();
+
+            asio_error_code err;
+            if (!accept_ready_.load()) {
+                asio::ip::tcp::socket unblock_socket(server_io_);
+                unblock_socket.connect(server_endpoint_, err);
+            }
+
+            std::shared_ptr<asio::ip::tcp::socket> socket;
+            {
+                std::lock_guard<std::mutex> guard(accepted_socket_lock_);
+                socket = accepted_socket_;
+            }
+
+            if (socket) {
+                socket->close(err);
+            }
+            acceptor_.close(err);
+            if (server_thread_.joinable()) {
+                server_thread_.join();
+            }
+        }
+    };
+    ServerThreadGuard server_thread_guard{
+        stop_server_ea,
+        server_io,
+        acceptor,
+        server_endpoint,
+        accepted_socket,
+        accepted_socket_lock,
+        accept_ready,
+        server_thread};
+
+    ptr<rpc_client> client =
+        svc.create_client("127.0.0.1:" + std::to_string(port));
+    CHK_NONNULL(client.get());
+
+    ptr<req_msg> req = cs_new<req_msg>(1,
+                                       msg_type::append_entries_request,
+                                       1,
+                                       2,
+                                       0,
+                                       0,
+                                       0);
+
+    EventAwaiter first_callback_ea;
+    EventAwaiter duplicate_callback_ea;
+    std::atomic<int> callback_count(0);
+    std::atomic<bool> got_error(false);
+
+    rpc_handler handler = [&](ptr<resp_msg>&, ptr<rpc_exception>& err) {
+        int count = callback_count.fetch_add(1) + 1;
+        got_error = (err != nullptr);
+        if (count == 1) {
+            first_callback_ea.invoke();
+            throw std::runtime_error("write request metadata callback exception");
+        }
+        duplicate_callback_ea.invoke();
+    };
+
+    client->send(req, handler, 0);
+    accepted_ea.wait_ms(3000);
+    CHK_TRUE( accept_ready.load() );
+
+    first_callback_ea.wait_ms(3000);
+    CHK_EQ( 1, callback_count.load() );
+    CHK_TRUE( got_error.load() );
+    CHK_TRUE( client->is_abandoned() );
+
+    duplicate_callback_ea.wait_ms(300);
+    CHK_EQ( 1, callback_count.load() );
+
+    svc.stop();
+
+    SimpleLogger::shutdown();
     return 0;
 }
 
@@ -2074,6 +2558,19 @@ int main(int argc, char** argv) {
     ts.doTest( "auto forwarding timeout test",
                auto_forwarding_timeout_test );
 
+    ts.doTest( "RPC response timeout invokes callback once test",
+               rpc_response_timeout_invokes_callback_once_test,
+               TestRange<bool>( {false, true} ) );
+
+    ts.doTest( "RPC response meta rejection throwing callback test",
+               rpc_response_meta_rejection_throwing_callback_test );
+
+    ts.doTest( "RPC custom resolver error throwing callback test",
+               rpc_custom_resolver_error_throwing_callback_test );
+
+    ts.doTest( "RPC write request metadata exception throwing callback test",
+               rpc_write_req_meta_exception_throwing_callback_test );
+
     ts.doTest( "auto forwarding test",
                auto_forwarding_test,
                TestRange<bool>( {false, true} ) );
@@ -2142,4 +2639,3 @@ int main(int argc, char** argv) {
 
     return 0;
 }
-

--- a/tests/unit/fake_network.cxx
+++ b/tests/unit/fake_network.cxx
@@ -290,6 +290,35 @@ size_t FakeNetwork::getNumPendingResps(const std::string& endpoint) {
     return conn->pendingResps.size();
 }
 
+int FakeNetwork::getFirstPendingReqType(const std::string& endpoint) {
+    ptr<FakeClient> conn = findClient(endpoint);
+    if (!conn || conn->pendingReqs.empty()) return -1;
+    return static_cast<int>(conn->pendingReqs.front().req->get_type());
+}
+
+uint64_t FakeNetwork::getFirstPendingReqTimeout(const std::string& endpoint) {
+    ptr<FakeClient> conn = findClient(endpoint);
+    if (!conn || conn->pendingReqs.empty()) return 0;
+    return conn->pendingReqs.front().timeoutMs;
+}
+
+ptr<peer> FakeNetwork::getPeer(raft_server* srv, int32 peer_id) {
+    auto& peers = get_peers(srv);
+    auto it = peers.find(peer_id);
+    if (it == peers.end()) return nullptr;
+    return it->second;
+}
+
+bool FakeNetwork::isPeerBusy(raft_server* srv, int32 peer_id) {
+    ptr<peer> pp = getPeer(srv, peer_id);
+    return pp ? pp->is_busy() : false;
+}
+
+bool FakeNetwork::doesPeerNeedToReconnect(raft_server* srv, int32 peer_id) {
+    ptr<peer> pp = getPeer(srv, peer_id);
+    return pp ? pp->need_to_reconnect() : false;
+}
+
 void FakeNetwork::stop() {
     handler = nullptr;
 }
@@ -320,14 +349,14 @@ FakeClient::~FakeClient() {}
 
 void FakeClient::send(ptr<req_msg>& req,
                       rpc_handler& when_done,
-                      uint64_t /*send_timeout_ms*/)
+                      uint64_t send_timeout_ms)
 {
     SimpleLogger* ll = motherNet->getBase()->getLogger();
     _log_info(ll, "got request %s -> %s, %s",
               motherNet->getEndpoint().c_str(),
               dstNet->getEndpoint().c_str(),
               msg_type_to_string( req->get_type() ).c_str() );
-    pendingReqs.push_back( FakeNetwork::ReqPkg(req, when_done) );
+    pendingReqs.push_back( FakeNetwork::ReqPkg(req, when_done, send_timeout_ms) );
 }
 
 void FakeClient::dropPackets() {
@@ -429,4 +458,3 @@ void FakeTimer::cancel_impl(ptr<delayed_task>& task) {
 }
 
 }  // namespace nuraft;
-

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -42,11 +42,12 @@ public:
                 ptr<FakeNetworkBase>& _base);
 
     struct ReqPkg {
-        ReqPkg(ptr<req_msg>& _req, rpc_handler& _when_done)
-            : req(_req), whenDone(_when_done)
+        ReqPkg(ptr<req_msg>& _req, rpc_handler& _when_done, uint64_t _timeout_ms)
+            : req(_req), whenDone(_when_done), timeoutMs(_timeout_ms)
             {}
         ptr<req_msg> req;
         rpc_handler whenDone;
+        uint64_t timeoutMs;
     };
 
     struct RespPkg {
@@ -89,6 +90,16 @@ public:
     size_t getNumPendingReqs(const std::string& endpoint);
 
     size_t getNumPendingResps(const std::string& endpoint);
+
+    int getFirstPendingReqType(const std::string& endpoint);
+
+    uint64_t getFirstPendingReqTimeout(const std::string& endpoint);
+
+    ptr<peer> getPeer(raft_server* srv, int32 peer_id);
+
+    bool isPeerBusy(raft_server* srv, int32 peer_id);
+
+    bool doesPeerNeedToReconnect(raft_server* srv, int32 peer_id);
 
     void goesOffline() { online = false; }
 

--- a/tests/unit/leader_election_test.cxx
+++ b/tests/unit/leader_election_test.cxx
@@ -25,6 +25,7 @@ limitations under the License.
 #include "test_common.h"
 
 #include <stdio.h>
+#include <stdexcept>
 
 using namespace nuraft;
 using namespace raft_functional_common;
@@ -964,6 +965,140 @@ int temporary_leader_test() {
     return 0;
 }
 
+int election_rpc_timeout_clears_stale_prevote_busy_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs ) );
+    CHK_Z( make_group( pkgs ) );
+
+    s2.dbgLog(" --- invoke election timer of S2 ---");
+    s2.fTimer->invoke( timer_task_type::election_timer );
+    s2.fNet->execReqResp();
+
+    s3.dbgLog(" --- invoke election timer of S3 ---");
+    s3.fTimer->invoke( timer_task_type::election_timer );
+
+    uint64_t election_timeout_ms =
+        s3.raftServer->get_current_params().election_timeout_upper_bound_;
+
+    CHK_EQ( 1, s3.fNet->getNumPendingReqs(s1_addr) );
+    CHK_EQ( static_cast<int>(msg_type::pre_vote_request),
+            s3.fNet->getFirstPendingReqType(s1_addr) );
+    CHK_EQ( election_timeout_ms, s3.fNet->getFirstPendingReqTimeout(s1_addr) );
+    CHK_TRUE( s3.fNet->isPeerBusy(s3.raftServer.get(), 1) );
+
+    s3.fNet->execReqResp(s2_addr);
+
+    CHK_EQ( 1, s3.fNet->getNumPendingReqs(s1_addr) );
+    CHK_EQ( static_cast<int>(msg_type::pre_vote_request),
+            s3.fNet->getFirstPendingReqType(s1_addr) );
+    CHK_TRUE( s3.fNet->isPeerBusy(s3.raftServer.get(), 1) );
+    CHK_EQ( 1, s3.fNet->getNumPendingReqs(s2_addr) );
+    CHK_EQ( static_cast<int>(msg_type::request_vote_request),
+            s3.fNet->getFirstPendingReqType(s2_addr) );
+    CHK_EQ( election_timeout_ms, s3.fNet->getFirstPendingReqTimeout(s2_addr) );
+
+    CHK_TRUE( s3.fNet->makeReqFail(s1_addr) );
+    CHK_Z( s3.fNet->getNumPendingReqs(s1_addr) );
+    CHK_FALSE( s3.fNet->isPeerBusy(s3.raftServer.get(), 1) );
+
+    s3.dbgLog(" --- invoke election timer of S3 after stale pre-vote timeout ---");
+    s3.fTimer->invoke( timer_task_type::election_timer );
+
+    CHK_EQ( 1, s3.fNet->getNumPendingReqs(s1_addr) );
+    CHK_EQ( static_cast<int>(msg_type::pre_vote_request),
+            s3.fNet->getFirstPendingReqType(s1_addr) );
+    CHK_EQ( election_timeout_ms, s3.fNet->getFirstPendingReqTimeout(s1_addr) );
+    CHK_TRUE( s3.fNet->isPeerBusy(s3.raftServer.get(), 1) );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    f_base->destroy();
+
+    return 0;
+}
+
+int peer_error_cleanup_before_throwing_handler_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs ) );
+    CHK_Z( make_group( pkgs ) );
+
+    ptr<peer> peer_to_s1 = s3.fNet->getPeer(s3.raftServer.get(), 1);
+    CHK_NONNULL(peer_to_s1.get());
+    CHK_TRUE(peer_to_s1->make_busy());
+
+    ptr<req_msg> req = cs_new<req_msg>(s3.raftServer->get_term(),
+                                       msg_type::pre_vote_request,
+                                       3,
+                                       1,
+                                       0,
+                                       0,
+                                       0);
+
+    std::atomic<int> callback_count(0);
+    rpc_handler throwing_handler =
+        [&callback_count](ptr<resp_msg>& resp, ptr<rpc_exception>& err) {
+            callback_count.fetch_add(1);
+            CHK_NULL(resp.get());
+            CHK_NONNULL(err.get());
+            throw std::runtime_error("peer RPC error handler exception");
+        };
+
+    peer_to_s1->send_req(peer_to_s1,
+                         req,
+                         throwing_handler,
+                         false,
+                         s3.raftServer->get_current_params().election_timeout_upper_bound_);
+
+    CHK_EQ( 1, s3.fNet->getNumPendingReqs(s1_addr) );
+
+    bool handler_threw = false;
+    try {
+        // `FakeNetwork` propagates handler exceptions directly. Production
+        // ASIO error completion catches them, but this test needs to verify
+        // peer cleanup before any handler exception can escape.
+        s3.fNet->makeReqFail(s1_addr);
+    } catch (const std::runtime_error&) {
+        handler_threw = true;
+    }
+
+    CHK_TRUE(handler_threw);
+    CHK_EQ( 1, callback_count.load() );
+    CHK_FALSE( s3.fNet->isPeerBusy(s3.raftServer.get(), 1) );
+    CHK_TRUE( s3.fNet->doesPeerNeedToReconnect(s3.raftServer.get(), 1) );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+
+    f_base->destroy();
+
+    return 0;
+}
+
 }  // namespace leader_election_test;
 using namespace leader_election_test;
 
@@ -1002,6 +1137,12 @@ int main(int argc, char** argv) {
     ts.doTest( "temporary leader test",
                temporary_leader_test );
 
+    ts.doTest( "election RPC timeout clears stale pre-vote busy test",
+               election_rpc_timeout_clears_stale_prevote_busy_test );
+
+    ts.doTest( "peer error cleanup before throwing handler test",
+               peer_error_cleanup_before_throwing_handler_test );
+
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");
 #else
@@ -1018,4 +1159,3 @@ int main(int argc, char** argv) {
 
     return 0;
 }
-


### PR DESCRIPTION
## Summary

Fix election RPCs so failed or timed-out pre-vote and vote requests clean up peer state instead of leaving peers stuck busy.

## Changes

- Pass election RPC timeouts through `peer::send_req`.
- Convert synchronous RPC send/setup failures into the normal RPC error path.
- Move peer cleanup before user callback invocation, since callbacks run synchronously and may throw.
- Add focused tests for stale election busy state and callback-once cleanup paths.
