### PR TITLE
Carry the installed snapshot index in the install-snapshot acknowledgement

### DIFF
--- a/include/libnuraft/raft_server_handler.hxx
+++ b/include/libnuraft/raft_server_handler.hxx
@@ -83,16 +83,12 @@ protected:
         return srv->create_append_entries_req(pp, custom_last_log_idx);
     }
 
-    /**
-     * Run the snapshot-install timeout check on a peer (for testing).
-     */
+    /// Runs a peer's snapshot-install timeout check (for testing).
     static bool check_snapshot_timeout(raft_server* srv, ptr<peer>& pp) {
         return srv->check_snapshot_timeout(pp);
     }
 
-    /**
-     * Get the pre-commit index of a raft_server (for testing).
-     */
+    /// Gets the server pre-commit index (for testing).
     static ulong get_precommit_index(raft_server* srv) {
         return srv->precommit_index_;
     }

--- a/include/libnuraft/raft_server_handler.hxx
+++ b/include/libnuraft/raft_server_handler.hxx
@@ -82,6 +82,20 @@ protected:
                                                   ulong custom_last_log_idx = 0) {
         return srv->create_append_entries_req(pp, custom_last_log_idx);
     }
+
+    /**
+     * Run the snapshot-install timeout check on a peer (for testing).
+     */
+    static bool check_snapshot_timeout(raft_server* srv, ptr<peer>& pp) {
+        return srv->check_snapshot_timeout(pp);
+    }
+
+    /**
+     * Get the pre-commit index of a raft_server (for testing).
+     */
+    static ulong get_precommit_index(raft_server* srv) {
+        return srv->precommit_index_;
+    }
 };
 
 }

--- a/include/libnuraft/raft_server_handler.hxx
+++ b/include/libnuraft/raft_server_handler.hxx
@@ -92,6 +92,17 @@ protected:
     static ulong get_precommit_index(raft_server* srv) {
         return srv->precommit_index_;
     }
+
+    /// Invokes the joining-server snapshot response handler (for testing).
+    static void handle_install_snapshot_resp_new_member(raft_server* srv,
+                                                        resp_msg& resp) {
+        srv->handle_install_snapshot_resp_new_member(resp);
+    }
+
+    /// Gets the server currently being added to the cluster (for testing).
+    static ptr<peer> get_srv_to_join(raft_server* srv) {
+        return srv->srv_to_join_;
+    }
 };
 
 }

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "raft_server.hxx"
 
+#include "buffer_serializer.hxx"
 #include "cluster_config.hxx"
 #include "context.hxx"
 #include "error_code.hxx"
@@ -32,10 +33,82 @@ limitations under the License.
 #include "state_mgr.hxx"
 #include "tracer.hxx"
 
+#include <algorithm>
 #include <cassert>
+#include <limits>
 #include <sstream>
 
 namespace nuraft {
+
+/**
+ * Terminal context of a logical-object `install_snapshot_response`, i.e. the payload a follower
+ * attaches to the response for the last object to say "the install is done".
+ *
+ * Originally this was a single zero byte, and the index of the installed snapshot lived
+ * exclusively in the leader's `snapshot_sync_ctx`. That made a completion uninterpretable -- and
+ * therefore droppable -- whenever the context was gone by the time the acknowledgement arrived,
+ * which is what happens when applying a large snapshot outruns `snapshot_sync_ctx_timeout`. The
+ * payload now carries the index itself, so the leader no longer needs the context to read it.
+ *
+ *  << Format >>
+ *  Format tag                       1 byte
+ *  Installed snapshot last_log_idx  8 bytes (little endian)
+ *
+ * `len == 1` with tag `LEGACY_NO_INDEX` is the historical payload and carries no index. For every
+ * tag `>= 1` bytes 1..8 are the installed snapshot's `last_log_idx`; keeping that prefix fixed
+ * lets a leader read the index out of a tag it does not otherwise understand, so later extensions
+ * of this format stay additive. Any other shape is malformed and must be rejected rather than
+ * read as a completion -- see `raft_server::handle_install_snapshot_resp`.
+ *
+ * An older leader never inspects this payload: for logical-object snapshots its completion test
+ * is only that `resp_msg::get_ctx` is non-null, which a 9-byte buffer satisfies just as well as a
+ * 1-byte one. So a follower on this format can acknowledge to a leader on either format.
+ */
+struct snp_install_done_ctx {
+    enum format_tag : uint8_t {
+        LEGACY_NO_INDEX = 0,
+        WITH_SNAPSHOT_IDX = 1,
+    };
+
+    static ptr<buffer> serialize(ulong last_log_idx) {
+        ptr<buffer> result = buffer::alloc(sizeof(uint8_t) + sizeof(uint64_t));
+        buffer_serializer bs(*result);
+        bs.put_u8(WITH_SNAPSHOT_IDX);
+        bs.put_u64(last_log_idx);
+        result->pos(0);
+        return result;
+    }
+
+    /**
+     * @param buf Terminal context received from a follower.
+     * @param last_log_idx_out Installed snapshot index, set only if the payload carries one.
+     * @param has_last_log_idx_out Whether the payload carries an index.
+     * @return `true` if the payload is a well-formed completion, `false` if it is malformed.
+     */
+    static bool parse(buffer& buf,
+                      ulong& last_log_idx_out,
+                      bool& has_last_log_idx_out)
+    {
+        has_last_log_idx_out = false;
+
+        if (buf.size() == sizeof(uint8_t)) {
+            // The historical payload, and nothing else, may be this short.
+            buffer_serializer bs(buf);
+            return bs.get_u8() == LEGACY_NO_INDEX;
+        }
+
+        if (buf.size() < sizeof(uint8_t) + sizeof(uint64_t)) return false;
+
+        buffer_serializer bs(buf);
+        // A payload long enough to hold an index but tagged as the indexless legacy one is
+        // inconsistent, so we cannot tell what it means.
+        if (bs.get_u8() == LEGACY_NO_INDEX) return false;
+
+        last_log_idx_out = bs.get_u64();
+        has_last_log_idx_out = true;
+        return true;
+    }
+};
 
 int32 raft_server::get_snapshot_sync_block_size() const {
     int32 block_size = ctx_->get_params()->snapshot_block_size_;
@@ -364,12 +437,12 @@ ptr<resp_msg> raft_server::handle_install_snapshot_req(req_msg& req, std::unique
             resp->accept(sync_req->get_offset());
             if (sync_req->is_done()) {
                 // TODO: check if there is missing object.
-                // Add a context buffer to inform installation is done.
-                ptr<buffer> done_ctx = buffer::alloc(1);
-                done_ctx->pos(0);
-                done_ctx->put((byte)0);
-                done_ctx->pos(0);
-                resp->set_ctx(done_ctx);
+                // Add a context buffer to inform installation is done. It names the snapshot
+                // that was installed, so that a leader which no longer has a sync context for
+                // this transfer -- because the install outran `snapshot_sync_ctx_timeout` --
+                // can still tell what this acknowledgement is about.
+                resp->set_ctx( snp_install_done_ctx::serialize(
+                                   sync_req->get_snapshot().get_last_log_idx() ) );
             }
         }
     }
@@ -392,10 +465,90 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
     if (resp.get_accepted()) {
         std::lock_guard<std::mutex> guard(p->get_lock());
         p->reset_cnt_backward_log_probe();
+
+        // A terminal context means the follower is done installing, and under
+        // `snp_install_done_ctx` it also names the snapshot that was installed -- the one thing
+        // the completion bookkeeping below actually needs from the sync context.
+        ulong acked_snp_idx = 0;
+        bool has_acked_snp_idx = false;
+        bool ctx_is_well_formed = true;
+        if (resp.get_ctx()) {
+            ctx_is_well_formed = snp_install_done_ctx::parse(
+                *resp.get_ctx(), acked_snp_idx, has_acked_snp_idx);
+        }
+
+        // Credit the peer with having installed `acked_idx`, if that claim survives validation.
+        // Every write is monotone, so an acknowledgement which arrives late -- or which turns out
+        // to be for a snapshot other than the one in flight -- can never move a peer backwards.
+        // That is what makes acting on an acknowledgement without its sync context safe at all.
+        auto advance_peer_to_acked_idx = [&](ulong acked_idx) -> bool {
+            if (resp.get_term() != state_->get_term()) {
+                p_wn("ignore the install of snapshot idx %" PRIu64 " acknowledged by peer %d: "
+                     "response term %" PRIu64 " is not the current term %" PRIu64,
+                     acked_idx, p->get_id(), resp.get_term(), state_->get_term());
+                return false;
+            }
+            if (acked_idx == 0 ||
+                acked_idx == std::numeric_limits<ulong>::max()) {
+                // Zero is never a snapshot boundary, and `acked_idx + 1` must not wrap.
+                p_wn("ignore the install acknowledged by peer %d: "
+                     "snapshot idx %" PRIu64 " is out of range",
+                     p->get_id(), acked_idx);
+                return false;
+            }
+            if (acked_idx > precommit_index_) {
+                // This server never wrote that index, so it cannot have sent a snapshot ending
+                // there either.
+                p_wn("ignore the install of snapshot idx %" PRIu64 " acknowledged by peer %d: "
+                     "it is beyond this server's precommit index %" PRIu64,
+                     acked_idx, p->get_id(), precommit_index_.load());
+                return false;
+            }
+
+            p->set_matched_idx( std::max( p->get_matched_idx(), acked_idx ) );
+            p->set_next_log_idx_floor(
+                std::max( p->get_next_log_idx_floor(), acked_idx + 1 ) );
+            p->set_next_log_idx( std::max( p->get_next_log_idx(), acked_idx + 1 ) );
+            return true;
+        };
+
         ptr<snapshot_sync_ctx> sync_ctx = p->get_snapshot_sync_ctx();
-        if (sync_ctx == nullptr) {
-            p_in("no snapshot sync context for this peer, drop the response");
+        if (!ctx_is_well_formed) {
+            // Neither the historical done-marker nor a well-formed extended payload, so we
+            // cannot tell which snapshot -- if any -- this is about. Reading it as a completion
+            // would mark whichever install is live as done, which is the misattribution the
+            // carried index exists to prevent, so drop it instead and leave every field and the
+            // live context alone. The cost is at most a retried install.
+            p_wn("peer %d sent an install snapshot response with a malformed terminal context "
+                 "of %zu bytes, drop the response",
+                 p->get_id(), resp.get_ctx()->size());
             need_to_catchup = false;
+
+        } else if (sync_ctx == nullptr) {
+            if (has_acked_snp_idx && advance_peer_to_acked_idx(acked_snp_idx)) {
+                // The install succeeded and said which snapshot it was for, so there is nothing
+                // left that the destroyed context was needed for. Complete the same bookkeeping
+                // a timely acknowledgement would have done, minus the context teardown. Clearing
+                // `snapshot_sync_is_needed` is the part that actually saves the retransfer: a
+                // follower which answered `RECEIVING_SNAPSHOT` while applying leaves that flag
+                // set, and `create_append_entries_req` would otherwise start a fresh install as
+                // soon as this server has a newer snapshot.
+                if (p->is_snapshot_sync_needed()) {
+                    p->set_snapshot_sync_is_needed(false);
+                    p_in("peer %d is no longer in snapshot sync mode", p->get_id());
+                }
+
+                need_to_catchup = p->clear_pending_commit() ||
+                                  p->get_next_log_idx() < log_store_->next_slot();
+                p_in("snapshot done %" PRIu64 ", %" PRIu64 ", %d "
+                     "(late acknowledgement of snapshot idx %" PRIu64
+                     ", the sync context was already gone)",
+                     p->get_next_log_idx(), p->get_matched_idx(), need_to_catchup,
+                     acked_snp_idx);
+            } else {
+                p_in("no snapshot sync context for this peer, drop the response");
+                need_to_catchup = false;
+            }
 
         } else {
             ptr<snapshot> snp = sync_ctx->get_snapshot();
@@ -412,7 +565,21 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
                  ( snp->get_type() == snapshot::logical_object &&
                    resp.get_ctx() );
 
-            if (snp_install_done) {
+            if ( snp_install_done && has_acked_snp_idx &&
+                 acked_snp_idx != snp->get_last_log_idx() ) {
+                // This acknowledgement is for a different snapshot than the one in flight,
+                // which is what a timed-out install restarted with a newer snapshot looks like.
+                // Completing the live transfer from it would set `matched_idx` to an index this
+                // peer never installed, and `matched_idx` feeds the commit-quorum calculation in
+                // `get_expected_committed_log_idx`. So credit only the index that really was
+                // installed, and leave the live transfer to finish and report on its own.
+                p_wn("peer %d acknowledged the install of snapshot idx %" PRIu64 " while "
+                     "snapshot idx %" PRIu64 " is in flight, "
+                     "do not treat the in-flight install as done",
+                     p->get_id(), acked_snp_idx, snp->get_last_log_idx());
+                advance_peer_to_acked_idx(acked_snp_idx);
+
+            } else if (snp_install_done) {
                 p_db("snapshot sync is done (raw type)");
                 p->set_next_log_idx(sync_ctx->get_snapshot()->get_last_log_idx() + 1);
                 p->set_matched_idx(sync_ctx->get_snapshot()->get_last_log_idx());

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -600,13 +600,68 @@ void raft_server::handle_install_snapshot_resp_new_member(resp_msg& resp) {
     }
     srv_to_join_->reset_resp_timer();
 
+    // A terminal context may identify the installed snapshot. Unlike an
+    // ordinary peer, a joining server is not in `peers_`, so it reaches this
+    // handler through `ex_resp_handler_`.
+    ulong acked_snp_idx = 0;
+    bool has_acked_snp_idx = false;
+    bool ctx_is_well_formed = true;
+    if (resp.get_ctx()) {
+        ctx_is_well_formed = snp_install_done_ctx::parse(
+            *resp.get_ctx(), acked_snp_idx, has_acked_snp_idx);
+    }
+
+    // Credit a terminal acknowledgement only when it belongs to the current
+    // leader term and describes a valid, already-written snapshot boundary.
+    auto advance_joiner_to_acked_idx = [&](ulong acked_idx) -> bool {
+        if (resp.get_term() != state_->get_term()) {
+            p_wn("ignore the install of snapshot idx %" PRIu64 " acknowledged by joining peer %d: "
+                 "response term %" PRIu64 " is not the current term %" PRIu64,
+                 acked_idx, srv_to_join_->get_id(), resp.get_term(), state_->get_term());
+            return false;
+        }
+        if (acked_idx == 0 ||
+            acked_idx == std::numeric_limits<ulong>::max()) {
+            p_wn("ignore the install acknowledged by joining peer %d: "
+                 "snapshot idx %" PRIu64 " is out of range",
+                 srv_to_join_->get_id(), acked_idx);
+            return false;
+        }
+        if (acked_idx > precommit_index_) {
+            p_wn("ignore the install of snapshot idx %" PRIu64 " acknowledged by joining peer %d: "
+                 "it is beyond this server's precommit index %" PRIu64,
+                 acked_idx, srv_to_join_->get_id(), precommit_index_.load());
+            return false;
+        }
+
+        srv_to_join_->set_matched_idx(
+            std::max(srv_to_join_->get_matched_idx(), acked_idx));
+        srv_to_join_->set_next_log_idx_floor(
+            std::max(srv_to_join_->get_next_log_idx_floor(), acked_idx + 1));
+        srv_to_join_->set_next_log_idx(
+            std::max(srv_to_join_->get_next_log_idx(), acked_idx + 1));
+        return true;
+    };
+
     ptr<snapshot_sync_ctx> sync_ctx = srv_to_join_->get_snapshot_sync_ctx();
+    if (!ctx_is_well_formed) {
+        p_wn("joining peer %d sent an install snapshot response with a malformed terminal context "
+             "of %zu bytes, drop the response",
+             srv_to_join_->get_id(), resp.get_ctx()->size());
+        return;
+    }
+
     if (sync_ctx == nullptr) {
-        p_ft("SnapshotSyncContext must not be null: "
-             "src %d dst %d my id %d leader id %d, "
-             "maybe leader election happened in the meantime. "
-             "next heartbeat or append request will cover it up.",
-             resp.get_src(), resp.get_dst(), id_, leader_.load());
+        if (has_acked_snp_idx && advance_joiner_to_acked_idx(acked_snp_idx)) {
+            p_in("snapshot install is done for joining peer %d: "
+                 "late acknowledgement of snapshot idx %" PRIu64
+                 ", the sync context was already gone",
+                 srv_to_join_->get_id(), acked_snp_idx);
+            sync_log_to_new_srv(srv_to_join_->get_next_log_idx());
+        } else {
+            p_in("no snapshot sync context for joining peer %d, drop the response",
+                 srv_to_join_->get_id());
+        }
         return;
     }
 
@@ -623,13 +678,23 @@ void raft_server::handle_install_snapshot_resp_new_member(resp_msg& resp) {
         ( snp->get_type() == snapshot::logical_object &&
           resp.get_ctx() );
 
-    if (snp_install_done) {
+    if ( snp_install_done && has_acked_snp_idx &&
+         acked_snp_idx != snp->get_last_log_idx() ) {
+        p_wn("joining peer %d acknowledged the install of snapshot idx %" PRIu64 " while "
+             "snapshot idx %" PRIu64 " is in flight, "
+             "do not treat the in-flight install as done",
+             srv_to_join_->get_id(), acked_snp_idx, snp->get_last_log_idx());
+        advance_joiner_to_acked_idx(acked_snp_idx);
+
+    } else if (snp_install_done) {
         // snapshot is done
         p_in("snapshot install is done\n");
         srv_to_join_->set_next_log_idx
             ( sync_ctx->get_snapshot()->get_last_log_idx() + 1 );
         srv_to_join_->set_matched_idx
             ( sync_ctx->get_snapshot()->get_last_log_idx() );
+        srv_to_join_->set_next_log_idx_floor
+            ( sync_ctx->get_snapshot()->get_last_log_idx() + 1 );
 
         clear_snapshot_sync_ctx(*srv_to_join_);
 

--- a/src/handle_snapshot_sync.cxx
+++ b/src/handle_snapshot_sync.cxx
@@ -41,28 +41,11 @@ limitations under the License.
 namespace nuraft {
 
 /**
- * Terminal context of a logical-object `install_snapshot_response`, i.e. the payload a follower
- * attaches to the response for the last object to say "the install is done".
+ * Completion context for logical-object snapshot installs.
  *
- * Originally this was a single zero byte, and the index of the installed snapshot lived
- * exclusively in the leader's `snapshot_sync_ctx`. That made a completion uninterpretable -- and
- * therefore droppable -- whenever the context was gone by the time the acknowledgement arrived,
- * which is what happens when applying a large snapshot outruns `snapshot_sync_ctx_timeout`. The
- * payload now carries the index itself, so the leader no longer needs the context to read it.
- *
- *  << Format >>
- *  Format tag                       1 byte
- *  Installed snapshot last_log_idx  8 bytes (little endian)
- *
- * `len == 1` with tag `LEGACY_NO_INDEX` is the historical payload and carries no index. For every
- * tag `>= 1` bytes 1..8 are the installed snapshot's `last_log_idx`; keeping that prefix fixed
- * lets a leader read the index out of a tag it does not otherwise understand, so later extensions
- * of this format stay additive. Any other shape is malformed and must be rejected rather than
- * read as a completion -- see `raft_server::handle_install_snapshot_resp`.
- *
- * An older leader never inspects this payload: for logical-object snapshots its completion test
- * is only that `resp_msg::get_ctx` is non-null, which a 9-byte buffer satisfies just as well as a
- * 1-byte one. So a follower on this format can acknowledge to a leader on either format.
+ * Legacy payloads are a one-byte `LEGACY_NO_INDEX` marker. New payloads store the installed
+ * `last_log_idx` after a nonzero tag. The fixed prefix permits additive format extensions and
+ * lets leaders process late acknowledgements after their `snapshot_sync_ctx` has expired.
  */
 struct snp_install_done_ctx {
     enum format_tag : uint8_t {
@@ -79,12 +62,7 @@ struct snp_install_done_ctx {
         return result;
     }
 
-    /**
-     * @param buf Terminal context received from a follower.
-     * @param last_log_idx_out Installed snapshot index, set only if the payload carries one.
-     * @param has_last_log_idx_out Whether the payload carries an index.
-     * @return `true` if the payload is a well-formed completion, `false` if it is malformed.
-     */
+    /// Parses a terminal context; sets the index output only when present.
     static bool parse(buffer& buf,
                       ulong& last_log_idx_out,
                       bool& has_last_log_idx_out)
@@ -92,7 +70,7 @@ struct snp_install_done_ctx {
         has_last_log_idx_out = false;
 
         if (buf.size() == sizeof(uint8_t)) {
-            // The historical payload, and nothing else, may be this short.
+            // Only the legacy marker may be this short.
             buffer_serializer bs(buf);
             return bs.get_u8() == LEGACY_NO_INDEX;
         }
@@ -100,8 +78,7 @@ struct snp_install_done_ctx {
         if (buf.size() < sizeof(uint8_t) + sizeof(uint64_t)) return false;
 
         buffer_serializer bs(buf);
-        // A payload long enough to hold an index but tagged as the indexless legacy one is
-        // inconsistent, so we cannot tell what it means.
+        // The legacy tag cannot carry an index.
         if (bs.get_u8() == LEGACY_NO_INDEX) return false;
 
         last_log_idx_out = bs.get_u64();
@@ -437,10 +414,7 @@ ptr<resp_msg> raft_server::handle_install_snapshot_req(req_msg& req, std::unique
             resp->accept(sync_req->get_offset());
             if (sync_req->is_done()) {
                 // TODO: check if there is missing object.
-                // Add a context buffer to inform installation is done. It names the snapshot
-                // that was installed, so that a leader which no longer has a sync context for
-                // this transfer -- because the install outran `snapshot_sync_ctx_timeout` --
-                // can still tell what this acknowledgement is about.
+                // Carry the installed snapshot index for late acknowledgements.
                 resp->set_ctx( snp_install_done_ctx::serialize(
                                    sync_req->get_snapshot().get_last_log_idx() ) );
             }
@@ -466,9 +440,7 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
         std::lock_guard<std::mutex> guard(p->get_lock());
         p->reset_cnt_backward_log_probe();
 
-        // A terminal context means the follower is done installing, and under
-        // `snp_install_done_ctx` it also names the snapshot that was installed -- the one thing
-        // the completion bookkeeping below actually needs from the sync context.
+        // A terminal context may identify the installed snapshot.
         ulong acked_snp_idx = 0;
         bool has_acked_snp_idx = false;
         bool ctx_is_well_formed = true;
@@ -477,10 +449,7 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
                 *resp.get_ctx(), acked_snp_idx, has_acked_snp_idx);
         }
 
-        // Credit the peer with having installed `acked_idx`, if that claim survives validation.
-        // Every write is monotone, so an acknowledgement which arrives late -- or which turns out
-        // to be for a snapshot other than the one in flight -- can never move a peer backwards.
-        // That is what makes acting on an acknowledgement without its sync context safe at all.
+        // Credit validated acknowledgements without moving progress backwards.
         auto advance_peer_to_acked_idx = [&](ulong acked_idx) -> bool {
             if (resp.get_term() != state_->get_term()) {
                 p_wn("ignore the install of snapshot idx %" PRIu64 " acknowledged by peer %d: "
@@ -490,15 +459,14 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
             }
             if (acked_idx == 0 ||
                 acked_idx == std::numeric_limits<ulong>::max()) {
-                // Zero is never a snapshot boundary, and `acked_idx + 1` must not wrap.
+                // A snapshot index must be nonzero and incrementable.
                 p_wn("ignore the install acknowledged by peer %d: "
                      "snapshot idx %" PRIu64 " is out of range",
                      p->get_id(), acked_idx);
                 return false;
             }
             if (acked_idx > precommit_index_) {
-                // This server never wrote that index, so it cannot have sent a snapshot ending
-                // there either.
+                // The leader cannot acknowledge an unwritten index.
                 p_wn("ignore the install of snapshot idx %" PRIu64 " acknowledged by peer %d: "
                      "it is beyond this server's precommit index %" PRIu64,
                      acked_idx, p->get_id(), precommit_index_.load());
@@ -514,11 +482,7 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
 
         ptr<snapshot_sync_ctx> sync_ctx = p->get_snapshot_sync_ctx();
         if (!ctx_is_well_formed) {
-            // Neither the historical done-marker nor a well-formed extended payload, so we
-            // cannot tell which snapshot -- if any -- this is about. Reading it as a completion
-            // would mark whichever install is live as done, which is the misattribution the
-            // carried index exists to prevent, so drop it instead and leave every field and the
-            // live context alone. The cost is at most a retried install.
+            // Malformed contexts must not complete an in-flight install.
             p_wn("peer %d sent an install snapshot response with a malformed terminal context "
                  "of %zu bytes, drop the response",
                  p->get_id(), resp.get_ctx()->size());
@@ -526,13 +490,7 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
 
         } else if (sync_ctx == nullptr) {
             if (has_acked_snp_idx && advance_peer_to_acked_idx(acked_snp_idx)) {
-                // The install succeeded and said which snapshot it was for, so there is nothing
-                // left that the destroyed context was needed for. Complete the same bookkeeping
-                // a timely acknowledgement would have done, minus the context teardown. Clearing
-                // `snapshot_sync_is_needed` is the part that actually saves the retransfer: a
-                // follower which answered `RECEIVING_SNAPSHOT` while applying leaves that flag
-                // set, and `create_append_entries_req` would otherwise start a fresh install as
-                // soon as this server has a newer snapshot.
+                // Complete late, indexed acknowledgements without a sync context.
                 if (p->is_snapshot_sync_needed()) {
                     p->set_snapshot_sync_is_needed(false);
                     p_in("peer %d is no longer in snapshot sync mode", p->get_id());
@@ -567,12 +525,7 @@ void raft_server::handle_install_snapshot_resp(resp_msg& resp) {
 
             if ( snp_install_done && has_acked_snp_idx &&
                  acked_snp_idx != snp->get_last_log_idx() ) {
-                // This acknowledgement is for a different snapshot than the one in flight,
-                // which is what a timed-out install restarted with a newer snapshot looks like.
-                // Completing the live transfer from it would set `matched_idx` to an index this
-                // peer never installed, and `matched_idx` feeds the commit-quorum calculation in
-                // `get_expected_committed_log_idx`. So credit only the index that really was
-                // installed, and leave the live transfer to finish and report on its own.
+                // Credit the acknowledged snapshot without completing the newer transfer.
                 p_wn("peer %d acknowledged the install of snapshot idx %" PRIu64 " while "
                      "snapshot idx %" PRIu64 " is in flight, "
                      "do not treat the in-flight install as done",

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -246,12 +246,30 @@ public:
 
     void setPeerSnapshotInSync(raft_server* srv,
                                int32 peer_id,
-                               ptr<snapshot> snp) {
+                               ptr<snapshot> snp,
+                               ulong timeout_ms = 10 * 1000) {
         auto& peers = get_peers(srv);
         auto it = peers.find(peer_id);
         if (it != peers.end()) {
-            it->second->set_snapshot_in_sync(snp);
+            it->second->set_snapshot_in_sync(snp, timeout_ms);
         }
+    }
+
+    /**
+     * Run the real snapshot-install timeout check, so a test can reach the
+     * post-timeout state through production code instead of emulating it.
+     */
+    bool checkPeerSnapshotTimeout(raft_server* srv, int32 peer_id) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            return check_snapshot_timeout(srv, it->second);
+        }
+        return false;
+    }
+
+    ulong getPrecommitIndex(raft_server* srv) {
+        return get_precommit_index(srv);
     }
 
     ulong getPeerSnapshotSyncCtxLastLogIdx(raft_server* srv, int32 peer_id) {

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -269,6 +269,55 @@ public:
         return get_precommit_index(srv);
     }
 
+    void setServerToJoinSnapshotInSync(raft_server* srv,
+                                       ptr<snapshot> snp,
+                                       ulong timeout_ms = 10 * 1000) {
+        ptr<peer> joiner = get_srv_to_join(srv);
+        if (joiner) {
+            joiner->set_snapshot_in_sync(snp, timeout_ms);
+        }
+    }
+
+    bool hasServerToJoinSnapshotSyncCtx(raft_server* srv) {
+        ptr<peer> joiner = get_srv_to_join(srv);
+        return joiner && joiner->get_snapshot_sync_ctx();
+    }
+
+    ulong getServerToJoinSnapshotSyncCtxLastLogIdx(raft_server* srv) {
+        ptr<peer> joiner = get_srv_to_join(srv);
+        if (joiner) {
+            ptr<snapshot_sync_ctx> sync_ctx = joiner->get_snapshot_sync_ctx();
+            if (sync_ctx && sync_ctx->get_snapshot()) {
+                return sync_ctx->get_snapshot()->get_last_log_idx();
+            }
+        }
+        return 0;
+    }
+
+    bool checkServerToJoinSnapshotTimeout(raft_server* srv) {
+        ptr<peer> joiner = get_srv_to_join(srv);
+        return joiner && check_snapshot_timeout(srv, joiner);
+    }
+
+    ulong getServerToJoinNextLogIdx(raft_server* srv) {
+        ptr<peer> joiner = get_srv_to_join(srv);
+        return joiner ? joiner->get_next_log_idx() : 0;
+    }
+
+    ulong getServerToJoinMatchedIdx(raft_server* srv) {
+        ptr<peer> joiner = get_srv_to_join(srv);
+        return joiner ? joiner->get_matched_idx() : 0;
+    }
+
+    ulong getServerToJoinNextLogIdxFloor(raft_server* srv) {
+        ptr<peer> joiner = get_srv_to_join(srv);
+        return joiner ? joiner->get_next_log_idx_floor() : 0;
+    }
+
+    void handleInstallSnapshotRespNewMember(raft_server* srv, resp_msg& resp) {
+        handle_install_snapshot_resp_new_member(srv, resp);
+    }
+
     ulong getPeerSnapshotSyncCtxLastLogIdx(raft_server* srv, int32 peer_id) {
         auto& peers = get_peers(srv);
         auto it = peers.find(peer_id);

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -255,10 +255,7 @@ public:
         }
     }
 
-    /**
-     * Run the real snapshot-install timeout check, so a test can reach the
-     * post-timeout state through production code instead of emulating it.
-     */
+    /// Runs the production snapshot-install timeout check.
     bool checkPeerSnapshotTimeout(raft_server* srv, int32 peer_id) {
         auto& peers = get_peers(srv);
         auto it = peers.find(peer_id);

--- a/tests/unit/snapshot_test.cxx
+++ b/tests/unit/snapshot_test.cxx
@@ -2373,26 +2373,9 @@ int snapshot_user_ctx_deferred_free_test()
     return 0;
 }
 
-// ---------------------------------------------------------------------------
-// Late snapshot-install acknowledgements.
-//
-// A follower answers the last snapshot object with a terminal context. The leader used to need
-// its own `snapshot_sync_ctx` to interpret that answer, because the installed snapshot's index
-// lived only there. Applying a large snapshot routinely outruns `snapshot_sync_ctx_timeout` --
-// which is a per-round-trip responsiveness budget, not an allowance for the apply -- so the
-// context was destroyed and a *successful* install was discarded, leaving `next_log_idx_floor`
-// unset and nothing to stop a subsequent backward log walk.
-//
-// The terminal context now carries the installed snapshot's `last_log_idx`, so these tests drive
-// the leader-side handling of that payload: which acknowledgements it acts on, which it refuses,
-// and what it must never do to a peer that has a *different* install in flight.
-// ---------------------------------------------------------------------------
+// Late snapshot-install acknowledgement tests.
 
-// Build a terminal install-snapshot context.
-//
-// `total_len` is explicit so the malformed and future-format cases can be expressed: the format
-// says `len == 1` with tag 0 is the historical indexless marker, and any tag `>= 1` carries the
-// index in bytes 1..8. Everything else is malformed.
+// Build a terminal context; `total_len` supports malformed and future formats.
 static ptr<buffer> make_snp_install_done_ctx(uint8_t tag,
                                              uint64_t snp_idx,
                                              size_t total_len) {
@@ -2409,24 +2392,14 @@ static ptr<buffer> make_snp_install_done_ctx(uint8_t tag,
     return ctx;
 }
 
-// Get a real response from S3 into the leader's pending queue, to be replaced with a crafted one
-// later.
-//
-// This has to happen before the state under test is arranged, and exactly once per delivery: a
-// heartbeat only produces a request while the peer is free, and with a snapshot sync context in
-// place it may produce no ordinary request at all.
+// Queue a real response to replace with a crafted response.
 static int arm_pending_resp(RaftPkg& leader, const std::string& peer_endpoint) {
     leader.fTimer->invoke( timer_task_type::heartbeat_timer );
     CHK_TRUE( leader.fNet->delieverReqTo(peer_endpoint) );
     return 0;
 }
 
-// Put the peer back into a state where `arm_pending_resp` works: no snapshot sync context, and a
-// cursor inside the leader's *available* log.
-//
-// The leader compacts its log up to the last snapshot, so a cursor below that boundary makes the
-// heartbeat start a snapshot transfer instead of producing the ordinary request we want to answer.
-// The state actually under test is set afterwards, once the response is already armed.
+// Reset the peer so a heartbeat produces an ordinary request.
 static void reset_peer_for_arming(RaftPkg& leader,
                                   int32 peer_id,
                                   ulong safe_next_log_idx) {
@@ -2448,7 +2421,7 @@ static void set_peer_cursor(RaftPkg& leader,
     leader.fNet->setPeerNextLogIdxFloor(leader.raftServer.get(), peer_id, floor_idx);
 }
 
-// Assert the peer's progress is exactly where it was left, i.e. the acknowledgement was refused.
+// Verify that a refused acknowledgement does not change peer progress.
 static int check_peer_cursor(RaftPkg& leader,
                              int32 peer_id,
                              ulong next_log_idx,
@@ -2473,7 +2446,7 @@ static int deliver_install_snapshot_resp(RaftPkg& leader,
     ptr<resp_msg> resp = cs_new<resp_msg>( term,
                                            msg_type::install_snapshot_response,
                                            peer_id,
-                                           1,   // dst = S1, the leader.
+                                           1,   // S1, the leader.
                                            next_idx,
                                            accepted );
     if (ctx) resp->set_ctx(ctx);
@@ -2482,8 +2455,7 @@ static int deliver_install_snapshot_resp(RaftPkg& leader,
     return 0;
 }
 
-// Bring up a three-node group, replicate enough entries for the leader to hold a snapshot, and
-// leave a crafted response armed for S3.
+// Three-node fixture with a leader snapshot.
 struct LateAckFixture {
     ptr<FakeNetworkBase> f_base;
     ptr<RaftPkg> s1;
@@ -2493,9 +2465,7 @@ struct LateAckFixture {
     ptr<snapshot> leader_snp;
     ulong precommit_idx = 0;
     ulong term = 0;
-    // A peer cursor that is inside the leader's uncompacted log, so a heartbeat produces an
-    // ordinary append rather than an install, and low enough that the leader never sees a peer
-    // claiming to be ahead of its own log.
+    // A cursor that permits ordinary replication.
     ulong safe_next_log_idx = 0;
 };
 
@@ -2539,9 +2509,7 @@ static void shutdown_late_ack_fixture(LateAckFixture& fx) {
     fx.f_base->destroy();
 }
 
-// Drive the real timeout check so the peer reaches the exact post-timeout state: the context is
-// destroyed, but `snapshot_sync_is_needed` -- which the timeout does not touch -- is left as it
-// was. A zero timeout makes `snapshot_sync_ctx::get_timer` report expiry on the first check.
+// Expire the context through the production timeout check.
 static int expire_snapshot_sync_ctx(RaftPkg& leader,
                                     int32 peer_id,
                                     ptr<snapshot> snp) {
@@ -2556,9 +2524,7 @@ static int expire_snapshot_sync_ctx(RaftPkg& leader,
     return 0;
 }
 
-// Case 1: the acknowledgement of a successful install is acted upon even though the sync context
-// it belonged to is already gone. This is the production failure, and the floor being set is the
-// part that stops the backward walk.
+// Case 1: accept a late acknowledgement after context expiry.
 int late_snapshot_install_ack_accepted_test() {
     LateAckFixture fx;
     CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
@@ -2569,8 +2535,7 @@ int late_snapshot_install_ack_accepted_test() {
     reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
     CHK_Z( arm_pending_resp(s1, "S3") );
 
-    // The peer looks far behind, as it does while it is still applying, and a backward walk has
-    // already started.
+    // Simulate an applying peer with an active backward probe.
     set_peer_cursor(s1, 3, 1, 0, 0);
     s1.fNet->setPeerBackwardLogProbeCount(s1.raftServer.get(), 3, 3);
 
@@ -2584,8 +2549,7 @@ int late_snapshot_install_ack_accepted_test() {
     CHK_EQ( snp_idx, s1.fNet->getPeerMatchedIdx(s1.raftServer.get(), 3) );
     CHK_EQ( snp_idx + 1,
             s1.fNet->getPeerNextLogIdxFloor(s1.raftServer.get(), 3) );
-    // A non-zero floor is what makes a backward walk impossible; the probe counter is also back
-    // to zero, so no walk is in progress either.
+    // The floor and reset probe counter prevent a backward walk.
     CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(s1.raftServer.get(), 3) );
 
     print_stats(fx.pkgs);
@@ -2593,9 +2557,7 @@ int late_snapshot_install_ack_accepted_test() {
     return 0;
 }
 
-// Case 2: the updates are monotone. A late acknowledgement for an old snapshot must not pull a
-// peer that has since advanced backwards -- that is the hazard which made dropping such
-// acknowledgements the safe choice in the first place.
+// Case 2: an old acknowledgement cannot move a peer backwards.
 int late_snapshot_install_ack_monotonic_test() {
     LateAckFixture fx;
     CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
@@ -2604,7 +2566,7 @@ int late_snapshot_install_ack_monotonic_test() {
     reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
     CHK_Z( arm_pending_resp(s1, "S3") );
 
-    // An index the leader really could have snapshotted, but long behind where the peer is now.
+    // A valid but stale snapshot index.
     ulong stale_idx = 3;
     CHK_GT( fx.leader_snp->get_last_log_idx(), stale_idx );
 
@@ -2626,10 +2588,7 @@ int late_snapshot_install_ack_monotonic_test() {
     return 0;
 }
 
-// Case 2b: the acknowledgement must also clear `snapshot_sync_is_needed`, otherwise the whole
-// point of accepting it is lost. A follower that answered `RECEIVING_SNAPSHOT` while applying
-// leaves that flag set, and the timeout does not clear it, so the next append cycle would start
-// another full install as soon as the leader holds a newer snapshot.
+// Case 2b: a late acknowledgement clears the sync-needed flag.
 int late_snapshot_install_ack_no_reinstall_test() {
     LateAckFixture fx;
     CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
@@ -2637,15 +2596,14 @@ int late_snapshot_install_ack_no_reinstall_test() {
 
     ulong snp_idx = fx.leader_snp->get_last_log_idx();
 
-    // Arm before the newer snapshot and the sync-needed flag are in place, so that this heartbeat
-    // is an ordinary one and does not itself start an install.
+    // Arm before setting the sync-needed flag.
     reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
     CHK_Z( arm_pending_resp(s1, "S3") );
 
     set_peer_cursor(s1, 3, 1, 0, 0);
     s1.fNet->setPeerSnapshotSyncNeeded(s1.raftServer.get(), 3, true);
 
-    // The leader moved on to a newer snapshot while the follower was applying the old one.
+    // The leader creates a newer snapshot while the follower applies the old one.
     ptr<snapshot> newer_snp =
         cs_new<snapshot>( snp_idx + 100,
                           fx.leader_snp->get_last_log_term(),
@@ -2662,9 +2620,7 @@ int late_snapshot_install_ack_no_reinstall_test() {
 
     CHK_FALSE( s1.fNet->getPeerSnapshotSyncNeeded(s1.raftServer.get(), 3) );
 
-    // With the flag cleared the peer is served ordinary log replication. Had it stayed set, this
-    // would be an `install_snapshot_request` for `newer_snp` -- the retransfer this fix exists to
-    // avoid.
+    // The next request is ordinary replication, not a reinstall.
     ptr<req_msg> req = s1.fNet->createAppendEntriesReq(s1.raftServer.get(), 3);
     CHK_NONNULL( req.get() );
     CHK_EQ( msg_type::append_entries_request, req->get_type() );
@@ -2674,9 +2630,7 @@ int late_snapshot_install_ack_no_reinstall_test() {
     return 0;
 }
 
-// Case 3: every index the leader acts on is validated first. Each of these acknowledgements is
-// accepted by the follower but carries an index the leader must refuse, and none of them may
-// touch the peer's progress.
+// Case 3: invalid acknowledgements do not change peer progress.
 int late_snapshot_install_ack_validation_test() {
     LateAckFixture fx;
     CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
@@ -2684,15 +2638,15 @@ int late_snapshot_install_ack_validation_test() {
 
     struct BadAck {
         const char* what;
-        ulong term_offset;   // Subtracted from the current term.
+        ulong term_offset;   // Offset from the current term.
         ulong idx;
     };
     std::vector<BadAck> bad_acks = {
-        // Beyond anything this leader ever wrote, so it cannot have sent such a snapshot.
+        // Beyond the leader's log.
         { "idx beyond precommit index", 0, fx.precommit_idx + 1 },
-        // From an earlier term: the peer state it describes may no longer be this leader's.
+        // From an earlier term.
         { "stale term", 1, fx.leader_snp->get_last_log_idx() },
-        // Never a snapshot boundary.
+        // Not a valid snapshot boundary.
         { "zero idx", 0, 0 },
         // `idx + 1` would wrap.
         { "max idx", 0, std::numeric_limits<ulong>::max() },
@@ -2717,9 +2671,7 @@ int late_snapshot_install_ack_validation_test() {
         CHK_Z( check_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx) );
     }
 
-    // A *declined* response is a different thing entirely: it means the follower is already past
-    // what we offered, and the existing handling deliberately rewrites the peer's position and
-    // zeroes the floor. Carrying the new payload must not change that.
+    // A declined response preserves existing cursor handling.
     _msg("  case: declined response with an extended payload\n");
     reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
     CHK_Z( arm_pending_resp(s1, "S3") );
@@ -2738,11 +2690,7 @@ int late_snapshot_install_ack_validation_test() {
     return 0;
 }
 
-// Case 4: an acknowledgement for snapshot `I` that arrives while an install of `J` is in flight
-// must not complete `J`. `matched_idx` feeds the commit-quorum calculation, so crediting the peer
-// with a snapshot it never installed is a safety problem, not just bookkeeping.
-//
-// This test fails on the unfixed code, where the terminal context is only ever a "done" flag.
+// Case 4: an old acknowledgement must not complete a newer install.
 int late_snapshot_install_ack_wrong_snapshot_test() {
     LateAckFixture fx;
     CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/true) );
@@ -2757,9 +2705,7 @@ int late_snapshot_install_ack_wrong_snapshot_test() {
 
     set_peer_cursor(s1, 3, 1, 0, 0);
 
-    // The install of `I` timed out, and the leader restarted the transfer with `J`. Marking the
-    // async read as in progress keeps the resumed transfer from being driven any further by the
-    // response we are about to deliver.
+    // The timed-out install of I is replaced by an in-progress install of J.
     ptr<snapshot> snp_i =
         cs_new<snapshot>( idx_i,
                           fx.leader_snp->get_last_log_term(),
@@ -2776,12 +2722,12 @@ int late_snapshot_install_ack_wrong_snapshot_test() {
                s1, "S3", 3, fx.term, true, 1,
                make_snp_install_done_ctx(1, idx_i, 9)) );
 
-    // `J` was not credited, and its transfer is still live and able to report for itself.
+    // J remains live and uncredited.
     CHK_EQ( idx_i, s1.fNet->getPeerMatchedIdx(s1.raftServer.get(), 3) );
     CHK_TRUE( s1.fNet->hasPeerSnapshotSyncCtx(s1.raftServer.get(), 3) );
     CHK_EQ( idx_j,
             s1.fNet->getPeerSnapshotSyncCtxLastLogIdx(s1.raftServer.get(), 3) );
-    // `I` really was installed, so it is credited.
+    // Credit the installed snapshot, I.
     CHK_EQ( idx_i + 1, s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
     CHK_EQ( idx_i + 1,
             s1.fNet->getPeerNextLogIdxFloor(s1.raftServer.get(), 3) );
@@ -2791,9 +2737,7 @@ int late_snapshot_install_ack_wrong_snapshot_test() {
     return 0;
 }
 
-// Case 5: a follower on the old format sends a one-byte marker with no index. Both outcomes are
-// unchanged from before this fix -- deliberately. The second one is the residue that a carried
-// index cannot fix, because there is nothing to correlate on.
+// Case 5: retain legacy marker behavior.
 int late_snapshot_install_ack_legacy_marker_test() {
     LateAckFixture fx;
     CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
@@ -2803,7 +2747,7 @@ int late_snapshot_install_ack_legacy_marker_test() {
     ulong matched_idx = next_log_idx - 1;
     ulong floor_idx = next_log_idx - 2;
 
-    // Without a context the response stays uninterpretable, so it is still dropped.
+    // An expired context leaves a legacy marker uninterpretable.
     reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
     CHK_Z( arm_pending_resp(s1, "S3") );
     set_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx);
@@ -2814,9 +2758,7 @@ int late_snapshot_install_ack_legacy_marker_test() {
 
     CHK_Z( check_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx) );
 
-    // With a context, the marker still completes whatever that context holds -- including pulling
-    // `matched_idx` back to that snapshot. An old follower gives the leader nothing to check that
-    // assumption against.
+    // A live context still completes from a legacy marker.
     ulong snp_idx = fx.leader_snp->get_last_log_idx();
     reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
     CHK_Z( arm_pending_resp(s1, "S3") );
@@ -2835,10 +2777,7 @@ int late_snapshot_install_ack_legacy_marker_test() {
     return 0;
 }
 
-// Case 6: a payload that is neither the historical marker nor a well-formed extended frame is
-// rejected outright. Falling back to "treat it as the old done-marker" would be the *permissive*
-// reading, because in this code the old marker means completion -- so a malformed acknowledgement
-// would complete whichever install happened to be live.
+// Case 6: malformed payloads cannot complete an install.
 int late_snapshot_install_ack_malformed_test() {
     LateAckFixture fx;
     CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
@@ -2855,9 +2794,9 @@ int late_snapshot_install_ack_malformed_test() {
         size_t len;
     };
     std::vector<Malformed> cases = {
-        // Long enough to hold an index but tagged as the indexless legacy payload.
+        // Legacy tag with an index-sized payload.
         { "legacy tag with an index-sized payload", 0, 9 },
-        // Claims an index it is too short to contain.
+        // Truncated index payload.
         { "index tag with a truncated payload", 1, 5 },
     };
 
@@ -2884,7 +2823,7 @@ int late_snapshot_install_ack_malformed_test() {
                        s1, 3, next_log_idx, matched_idx, floor_idx) );
 
             if (with_live_ctx) {
-                // The live transfer survives an unreadable response.
+                // The live transfer survives.
                 CHK_TRUE( s1.fNet->hasPeerSnapshotSyncCtx(
                               s1.raftServer.get(), 3) );
                 CHK_EQ( idx_j,
@@ -2899,9 +2838,7 @@ int late_snapshot_install_ack_malformed_test() {
     return 0;
 }
 
-// Case 7: the index sits at a fixed offset for every tag `>= 1`, so a leader can read it out of a
-// format it does not otherwise understand. That keeps later extensions of this payload additive
-// instead of being rejected by older peers.
+// Case 7: unknown nonzero tags retain the fixed index prefix.
 int late_snapshot_install_ack_future_format_test() {
     LateAckFixture fx;
     CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );

--- a/tests/unit/snapshot_test.cxx
+++ b/tests/unit/snapshot_test.cxx
@@ -2524,6 +2524,88 @@ static int expire_snapshot_sync_ctx(RaftPkg& leader,
     return 0;
 }
 
+static ptr<resp_msg> make_install_snapshot_resp(int32 peer_id,
+                                                ulong term,
+                                                ptr<buffer> ctx) {
+    ptr<resp_msg> resp = cs_new<resp_msg>( term,
+                                           msg_type::install_snapshot_response,
+                                           peer_id,
+                                           1,   // S1, the leader.
+                                           1,
+                                           true );
+    resp->set_ctx(ctx);
+    return resp;
+}
+
+// A joining server has its own response handler. It must recover when the
+// final snapshot acknowledgement arrives after its context has timed out.
+int late_snapshot_install_ack_new_member_test() {
+    LateAckFixture fx;
+    CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
+    RaftPkg& s1 = *fx.s1;
+
+    RaftPkg s4(fx.f_base, 4, std::string("S4"));
+    CHK_Z( launch_servers( {&s4} ) );
+    s1.raftServer->add_srv( *(s4.getTestMgr()->get_srv_config()) );
+
+    ulong snp_idx = fx.leader_snp->get_last_log_idx();
+    s1.fNet->setServerToJoinSnapshotInSync(
+        s1.raftServer.get(), fx.leader_snp, /*timeout_ms=*/0);
+    CHK_TRUE( s1.fNet->hasServerToJoinSnapshotSyncCtx(s1.raftServer.get()) );
+    CHK_TRUE( s1.fNet->checkServerToJoinSnapshotTimeout(s1.raftServer.get()) );
+    CHK_FALSE( s1.fNet->hasServerToJoinSnapshotSyncCtx(s1.raftServer.get()) );
+
+    ptr<resp_msg> resp = make_install_snapshot_resp(
+        4, fx.term, make_snp_install_done_ctx(1, snp_idx, 9));
+    s1.fNet->handleInstallSnapshotRespNewMember(s1.raftServer.get(), *resp);
+
+    CHK_EQ( snp_idx + 1,
+            s1.fNet->getServerToJoinNextLogIdx(s1.raftServer.get()) );
+    CHK_EQ( snp_idx,
+            s1.fNet->getServerToJoinMatchedIdx(s1.raftServer.get()) );
+    CHK_EQ( snp_idx + 1,
+            s1.fNet->getServerToJoinNextLogIdxFloor(s1.raftServer.get()) );
+
+    s4.raftServer->shutdown();
+    shutdown_late_ack_fixture(fx);
+    return 0;
+}
+
+// A late acknowledgement for an older snapshot must not complete the newer
+// snapshot currently being transferred to the joining server.
+int late_snapshot_install_ack_new_member_wrong_snapshot_test() {
+    LateAckFixture fx;
+    CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
+    RaftPkg& s1 = *fx.s1;
+
+    RaftPkg s4(fx.f_base, 4, std::string("S4"));
+    CHK_Z( launch_servers( {&s4} ) );
+    s1.raftServer->add_srv( *(s4.getTestMgr()->get_srv_config()) );
+
+    ulong idx_i = fx.leader_snp->get_last_log_idx();
+    ptr<snapshot> snp_j = cs_new<snapshot>(
+        idx_i + 1,
+        fx.leader_snp->get_last_log_term(),
+        fx.leader_snp->get_last_config(),
+        0,
+        snapshot::logical_object );
+    s1.fNet->setServerToJoinSnapshotInSync(s1.raftServer.get(), snp_j);
+
+    ptr<resp_msg> resp = make_install_snapshot_resp(
+        4, fx.term, make_snp_install_done_ctx(1, idx_i, 9));
+    s1.fNet->handleInstallSnapshotRespNewMember(s1.raftServer.get(), *resp);
+
+    CHK_TRUE( s1.fNet->hasServerToJoinSnapshotSyncCtx(s1.raftServer.get()) );
+    CHK_EQ( snp_j->get_last_log_idx(),
+            s1.fNet->getServerToJoinSnapshotSyncCtxLastLogIdx(s1.raftServer.get()) );
+    CHK_EQ( idx_i,
+            s1.fNet->getServerToJoinMatchedIdx(s1.raftServer.get()) );
+
+    s4.raftServer->shutdown();
+    shutdown_late_ack_fixture(fx);
+    return 0;
+}
+
 // Case 1: accept a late acknowledgement after context expiry.
 int late_snapshot_install_ack_accepted_test() {
     LateAckFixture fx;
@@ -2955,6 +3037,12 @@ int main(int argc, char* argv[]) {
 
     ts.doTest( "late snapshot install ack accepted test",
                late_snapshot_install_ack_accepted_test );
+
+    ts.doTest( "late snapshot install ack new member test",
+               late_snapshot_install_ack_new_member_test );
+
+    ts.doTest( "late snapshot install ack new member wrong snapshot test",
+               late_snapshot_install_ack_new_member_wrong_snapshot_test );
 
     ts.doTest( "late snapshot install ack monotonic test",
                late_snapshot_install_ack_monotonic_test );

--- a/tests/unit/snapshot_test.cxx
+++ b/tests/unit/snapshot_test.cxx
@@ -2373,6 +2373,566 @@ int snapshot_user_ctx_deferred_free_test()
     return 0;
 }
 
+// ---------------------------------------------------------------------------
+// Late snapshot-install acknowledgements.
+//
+// A follower answers the last snapshot object with a terminal context. The leader used to need
+// its own `snapshot_sync_ctx` to interpret that answer, because the installed snapshot's index
+// lived only there. Applying a large snapshot routinely outruns `snapshot_sync_ctx_timeout` --
+// which is a per-round-trip responsiveness budget, not an allowance for the apply -- so the
+// context was destroyed and a *successful* install was discarded, leaving `next_log_idx_floor`
+// unset and nothing to stop a subsequent backward log walk.
+//
+// The terminal context now carries the installed snapshot's `last_log_idx`, so these tests drive
+// the leader-side handling of that payload: which acknowledgements it acts on, which it refuses,
+// and what it must never do to a peer that has a *different* install in flight.
+// ---------------------------------------------------------------------------
+
+// Build a terminal install-snapshot context.
+//
+// `total_len` is explicit so the malformed and future-format cases can be expressed: the format
+// says `len == 1` with tag 0 is the historical indexless marker, and any tag `>= 1` carries the
+// index in bytes 1..8. Everything else is malformed.
+static ptr<buffer> make_snp_install_done_ctx(uint8_t tag,
+                                             uint64_t snp_idx,
+                                             size_t total_len) {
+    ptr<buffer> ctx = buffer::alloc(total_len);
+    buffer_serializer bs(*ctx);
+    bs.put_u8(tag);
+    if (total_len >= sizeof(uint8_t) + sizeof(uint64_t)) {
+        bs.put_u64(snp_idx);
+    }
+    while (bs.pos() < total_len) {
+        bs.put_u8(0);
+    }
+    ctx->pos(0);
+    return ctx;
+}
+
+// Get a real response from S3 into the leader's pending queue, to be replaced with a crafted one
+// later.
+//
+// This has to happen before the state under test is arranged, and exactly once per delivery: a
+// heartbeat only produces a request while the peer is free, and with a snapshot sync context in
+// place it may produce no ordinary request at all.
+static int arm_pending_resp(RaftPkg& leader, const std::string& peer_endpoint) {
+    leader.fTimer->invoke( timer_task_type::heartbeat_timer );
+    CHK_TRUE( leader.fNet->delieverReqTo(peer_endpoint) );
+    return 0;
+}
+
+// Put the peer back into a state where `arm_pending_resp` works: no snapshot sync context, and a
+// cursor inside the leader's *available* log.
+//
+// The leader compacts its log up to the last snapshot, so a cursor below that boundary makes the
+// heartbeat start a snapshot transfer instead of producing the ordinary request we want to answer.
+// The state actually under test is set afterwards, once the response is already armed.
+static void reset_peer_for_arming(RaftPkg& leader,
+                                  int32 peer_id,
+                                  ulong safe_next_log_idx) {
+    leader.fNet->setPeerSnapshotInSync(leader.raftServer.get(), peer_id, nullptr);
+    leader.fNet->setPeerNextLogIdx(
+        leader.raftServer.get(), peer_id, safe_next_log_idx);
+    leader.fNet->setPeerMatchedIdx(
+        leader.raftServer.get(), peer_id, safe_next_log_idx - 1);
+    leader.fNet->setPeerNextLogIdxFloor(leader.raftServer.get(), peer_id, 0);
+}
+
+static void set_peer_cursor(RaftPkg& leader,
+                            int32 peer_id,
+                            ulong next_log_idx,
+                            ulong matched_idx,
+                            ulong floor_idx) {
+    leader.fNet->setPeerNextLogIdx(leader.raftServer.get(), peer_id, next_log_idx);
+    leader.fNet->setPeerMatchedIdx(leader.raftServer.get(), peer_id, matched_idx);
+    leader.fNet->setPeerNextLogIdxFloor(leader.raftServer.get(), peer_id, floor_idx);
+}
+
+// Assert the peer's progress is exactly where it was left, i.e. the acknowledgement was refused.
+static int check_peer_cursor(RaftPkg& leader,
+                             int32 peer_id,
+                             ulong next_log_idx,
+                             ulong matched_idx,
+                             ulong floor_idx) {
+    CHK_EQ( next_log_idx,
+            leader.fNet->getPeerNextLogIdx(leader.raftServer.get(), peer_id) );
+    CHK_EQ( matched_idx,
+            leader.fNet->getPeerMatchedIdx(leader.raftServer.get(), peer_id) );
+    CHK_EQ( floor_idx,
+            leader.fNet->getPeerNextLogIdxFloor(leader.raftServer.get(), peer_id) );
+    return 0;
+}
+
+static int deliver_install_snapshot_resp(RaftPkg& leader,
+                                         const std::string& peer_endpoint,
+                                         int32 peer_id,
+                                         ulong term,
+                                         bool accepted,
+                                         ulong next_idx,
+                                         ptr<buffer> ctx) {
+    ptr<resp_msg> resp = cs_new<resp_msg>( term,
+                                           msg_type::install_snapshot_response,
+                                           peer_id,
+                                           1,   // dst = S1, the leader.
+                                           next_idx,
+                                           accepted );
+    if (ctx) resp->set_ctx(ctx);
+    CHK_TRUE( leader.fNet->replaceLastPendingResp(peer_endpoint, resp) );
+    CHK_TRUE( leader.fNet->handleRespFrom(peer_endpoint) );
+    return 0;
+}
+
+// Bring up a three-node group, replicate enough entries for the leader to hold a snapshot, and
+// leave a crafted response armed for S3.
+struct LateAckFixture {
+    ptr<FakeNetworkBase> f_base;
+    ptr<RaftPkg> s1;
+    ptr<RaftPkg> s2;
+    ptr<RaftPkg> s3;
+    std::vector<RaftPkg*> pkgs;
+    ptr<snapshot> leader_snp;
+    ulong precommit_idx = 0;
+    ulong term = 0;
+    // A peer cursor that is inside the leader's uncompacted log, so a heartbeat produces an
+    // ordinary append rather than an install, and low enough that the leader never sees a peer
+    // claiming to be ahead of its own log.
+    ulong safe_next_log_idx = 0;
+};
+
+static int setup_late_ack_fixture(LateAckFixture& fx,
+                                 bool use_bg_thread_for_snapshot_io) {
+    reset_log_files();
+    fx.f_base = cs_new<FakeNetworkBase>();
+
+    fx.s1 = cs_new<RaftPkg>(fx.f_base, 1, std::string("S1"));
+    fx.s2 = cs_new<RaftPkg>(fx.f_base, 2, std::string("S2"));
+    fx.s3 = cs_new<RaftPkg>(fx.f_base, 3, std::string("S3"));
+    fx.pkgs = {fx.s1.get(), fx.s2.get(), fx.s3.get()};
+
+    CHK_Z( launch_servers( fx.pkgs ) );
+    CHK_Z( make_group( fx.pkgs ) );
+
+    for (auto& entry: fx.pkgs) {
+        raft_params param = entry->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.snapshot_distance_ = 5;
+        param.use_bg_thread_for_snapshot_io_ = use_bg_thread_for_snapshot_io;
+        entry->raftServer->update_params(param);
+    }
+
+    CHK_Z( append_and_replicate(*fx.s1, fx.pkgs, 0, 20) );
+
+    fx.leader_snp = fx.s1->fNet->getLastSnapshot(fx.s1->raftServer.get());
+    CHK_NONNULL( fx.leader_snp.get() );
+    fx.precommit_idx = fx.s1->fNet->getPrecommitIndex(fx.s1->raftServer.get());
+    fx.term = fx.s1->raftServer->get_term();
+    fx.safe_next_log_idx = fx.precommit_idx;
+    CHK_GT( fx.safe_next_log_idx, fx.leader_snp->get_last_log_idx() );
+
+    return 0;
+}
+
+static void shutdown_late_ack_fixture(LateAckFixture& fx) {
+    fx.s1->raftServer->shutdown();
+    fx.s2->raftServer->shutdown();
+    fx.s3->raftServer->shutdown();
+    fx.f_base->destroy();
+}
+
+// Drive the real timeout check so the peer reaches the exact post-timeout state: the context is
+// destroyed, but `snapshot_sync_is_needed` -- which the timeout does not touch -- is left as it
+// was. A zero timeout makes `snapshot_sync_ctx::get_timer` report expiry on the first check.
+static int expire_snapshot_sync_ctx(RaftPkg& leader,
+                                    int32 peer_id,
+                                    ptr<snapshot> snp) {
+    leader.fNet->setPeerSnapshotInSync(
+        leader.raftServer.get(), peer_id, snp, /*timeout_ms=*/0);
+    CHK_TRUE( leader.fNet->hasPeerSnapshotSyncCtx(
+                  leader.raftServer.get(), peer_id) );
+    CHK_TRUE( leader.fNet->checkPeerSnapshotTimeout(
+                  leader.raftServer.get(), peer_id) );
+    CHK_FALSE( leader.fNet->hasPeerSnapshotSyncCtx(
+                   leader.raftServer.get(), peer_id) );
+    return 0;
+}
+
+// Case 1: the acknowledgement of a successful install is acted upon even though the sync context
+// it belonged to is already gone. This is the production failure, and the floor being set is the
+// part that stops the backward walk.
+int late_snapshot_install_ack_accepted_test() {
+    LateAckFixture fx;
+    CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
+    RaftPkg& s1 = *fx.s1;
+
+    ulong snp_idx = fx.leader_snp->get_last_log_idx();
+
+    reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
+    CHK_Z( arm_pending_resp(s1, "S3") );
+
+    // The peer looks far behind, as it does while it is still applying, and a backward walk has
+    // already started.
+    set_peer_cursor(s1, 3, 1, 0, 0);
+    s1.fNet->setPeerBackwardLogProbeCount(s1.raftServer.get(), 3, 3);
+
+    CHK_Z( expire_snapshot_sync_ctx(s1, 3, fx.leader_snp) );
+
+    CHK_Z( deliver_install_snapshot_resp(
+               s1, "S3", 3, fx.term, true, 1,
+               make_snp_install_done_ctx(1, snp_idx, 9)) );
+
+    CHK_EQ( snp_idx + 1, s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
+    CHK_EQ( snp_idx, s1.fNet->getPeerMatchedIdx(s1.raftServer.get(), 3) );
+    CHK_EQ( snp_idx + 1,
+            s1.fNet->getPeerNextLogIdxFloor(s1.raftServer.get(), 3) );
+    // A non-zero floor is what makes a backward walk impossible; the probe counter is also back
+    // to zero, so no walk is in progress either.
+    CHK_EQ( 0, s1.fNet->getPeerBackwardLogProbeCount(s1.raftServer.get(), 3) );
+
+    print_stats(fx.pkgs);
+    shutdown_late_ack_fixture(fx);
+    return 0;
+}
+
+// Case 2: the updates are monotone. A late acknowledgement for an old snapshot must not pull a
+// peer that has since advanced backwards -- that is the hazard which made dropping such
+// acknowledgements the safe choice in the first place.
+int late_snapshot_install_ack_monotonic_test() {
+    LateAckFixture fx;
+    CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
+    RaftPkg& s1 = *fx.s1;
+
+    reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
+    CHK_Z( arm_pending_resp(s1, "S3") );
+
+    // An index the leader really could have snapshotted, but long behind where the peer is now.
+    ulong stale_idx = 3;
+    CHK_GT( fx.leader_snp->get_last_log_idx(), stale_idx );
+
+    ulong next_log_idx = fx.safe_next_log_idx;
+    ulong matched_idx = next_log_idx - 1;
+    ulong floor_idx = next_log_idx - 2;
+    set_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx);
+
+    CHK_Z( expire_snapshot_sync_ctx(s1, 3, fx.leader_snp) );
+
+    CHK_Z( deliver_install_snapshot_resp(
+               s1, "S3", 3, fx.term, true, 1,
+               make_snp_install_done_ctx(1, stale_idx, 9)) );
+
+    CHK_Z( check_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx) );
+
+    print_stats(fx.pkgs);
+    shutdown_late_ack_fixture(fx);
+    return 0;
+}
+
+// Case 2b: the acknowledgement must also clear `snapshot_sync_is_needed`, otherwise the whole
+// point of accepting it is lost. A follower that answered `RECEIVING_SNAPSHOT` while applying
+// leaves that flag set, and the timeout does not clear it, so the next append cycle would start
+// another full install as soon as the leader holds a newer snapshot.
+int late_snapshot_install_ack_no_reinstall_test() {
+    LateAckFixture fx;
+    CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
+    RaftPkg& s1 = *fx.s1;
+
+    ulong snp_idx = fx.leader_snp->get_last_log_idx();
+
+    // Arm before the newer snapshot and the sync-needed flag are in place, so that this heartbeat
+    // is an ordinary one and does not itself start an install.
+    reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
+    CHK_Z( arm_pending_resp(s1, "S3") );
+
+    set_peer_cursor(s1, 3, 1, 0, 0);
+    s1.fNet->setPeerSnapshotSyncNeeded(s1.raftServer.get(), 3, true);
+
+    // The leader moved on to a newer snapshot while the follower was applying the old one.
+    ptr<snapshot> newer_snp =
+        cs_new<snapshot>( snp_idx + 100,
+                          fx.leader_snp->get_last_log_term(),
+                          fx.leader_snp->get_last_config(),
+                          0,
+                          snapshot::logical_object );
+    s1.fNet->setLastSnapshot(s1.raftServer.get(), newer_snp);
+
+    CHK_Z( expire_snapshot_sync_ctx(s1, 3, fx.leader_snp) );
+
+    CHK_Z( deliver_install_snapshot_resp(
+               s1, "S3", 3, fx.term, true, 1,
+               make_snp_install_done_ctx(1, snp_idx, 9)) );
+
+    CHK_FALSE( s1.fNet->getPeerSnapshotSyncNeeded(s1.raftServer.get(), 3) );
+
+    // With the flag cleared the peer is served ordinary log replication. Had it stayed set, this
+    // would be an `install_snapshot_request` for `newer_snp` -- the retransfer this fix exists to
+    // avoid.
+    ptr<req_msg> req = s1.fNet->createAppendEntriesReq(s1.raftServer.get(), 3);
+    CHK_NONNULL( req.get() );
+    CHK_EQ( msg_type::append_entries_request, req->get_type() );
+
+    print_stats(fx.pkgs);
+    shutdown_late_ack_fixture(fx);
+    return 0;
+}
+
+// Case 3: every index the leader acts on is validated first. Each of these acknowledgements is
+// accepted by the follower but carries an index the leader must refuse, and none of them may
+// touch the peer's progress.
+int late_snapshot_install_ack_validation_test() {
+    LateAckFixture fx;
+    CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
+    RaftPkg& s1 = *fx.s1;
+
+    struct BadAck {
+        const char* what;
+        ulong term_offset;   // Subtracted from the current term.
+        ulong idx;
+    };
+    std::vector<BadAck> bad_acks = {
+        // Beyond anything this leader ever wrote, so it cannot have sent such a snapshot.
+        { "idx beyond precommit index", 0, fx.precommit_idx + 1 },
+        // From an earlier term: the peer state it describes may no longer be this leader's.
+        { "stale term", 1, fx.leader_snp->get_last_log_idx() },
+        // Never a snapshot boundary.
+        { "zero idx", 0, 0 },
+        // `idx + 1` would wrap.
+        { "max idx", 0, std::numeric_limits<ulong>::max() },
+    };
+
+    ulong next_log_idx = fx.safe_next_log_idx;
+    ulong matched_idx = next_log_idx - 1;
+    ulong floor_idx = next_log_idx - 2;
+
+    for (auto& bad_ack: bad_acks) {
+        _msg("  case: %s\n", bad_ack.what);
+
+        reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
+        CHK_Z( arm_pending_resp(s1, "S3") );
+
+        set_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx);
+        CHK_Z( expire_snapshot_sync_ctx(s1, 3, fx.leader_snp) );
+        CHK_Z( deliver_install_snapshot_resp(
+                   s1, "S3", 3, fx.term - bad_ack.term_offset, true, 1,
+                   make_snp_install_done_ctx(1, bad_ack.idx, 9)) );
+
+        CHK_Z( check_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx) );
+    }
+
+    // A *declined* response is a different thing entirely: it means the follower is already past
+    // what we offered, and the existing handling deliberately rewrites the peer's position and
+    // zeroes the floor. Carrying the new payload must not change that.
+    _msg("  case: declined response with an extended payload\n");
+    reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
+    CHK_Z( arm_pending_resp(s1, "S3") );
+    set_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx);
+    CHK_Z( deliver_install_snapshot_resp(
+               s1, "S3", 3, fx.term, false, next_log_idx + 1,
+               make_snp_install_done_ctx(
+                   1, fx.leader_snp->get_last_log_idx(), 9)) );
+
+    CHK_EQ( next_log_idx + 1,
+            s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
+    CHK_EQ( 0, s1.fNet->getPeerNextLogIdxFloor(s1.raftServer.get(), 3) );
+
+    print_stats(fx.pkgs);
+    shutdown_late_ack_fixture(fx);
+    return 0;
+}
+
+// Case 4: an acknowledgement for snapshot `I` that arrives while an install of `J` is in flight
+// must not complete `J`. `matched_idx` feeds the commit-quorum calculation, so crediting the peer
+// with a snapshot it never installed is a safety problem, not just bookkeeping.
+//
+// This test fails on the unfixed code, where the terminal context is only ever a "done" flag.
+int late_snapshot_install_ack_wrong_snapshot_test() {
+    LateAckFixture fx;
+    CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/true) );
+    RaftPkg& s1 = *fx.s1;
+
+    ulong idx_i = 3;
+    ulong idx_j = fx.leader_snp->get_last_log_idx();
+    CHK_GT( idx_j, idx_i );
+
+    reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
+    CHK_Z( arm_pending_resp(s1, "S3") );
+
+    set_peer_cursor(s1, 3, 1, 0, 0);
+
+    // The install of `I` timed out, and the leader restarted the transfer with `J`. Marking the
+    // async read as in progress keeps the resumed transfer from being driven any further by the
+    // response we are about to deliver.
+    ptr<snapshot> snp_i =
+        cs_new<snapshot>( idx_i,
+                          fx.leader_snp->get_last_log_term(),
+                          fx.leader_snp->get_last_config(),
+                          0,
+                          snapshot::logical_object );
+    CHK_Z( expire_snapshot_sync_ctx(s1, 3, snp_i) );
+
+    s1.fNet->setPeerSnapshotInSync(s1.raftServer.get(), 3, fx.leader_snp);
+    s1.fNet->beginPeerSnapshotAsyncRequest(s1.raftServer.get(), 3);
+    CHK_TRUE( s1.fNet->hasPeerSnapshotSyncCtx(s1.raftServer.get(), 3) );
+
+    CHK_Z( deliver_install_snapshot_resp(
+               s1, "S3", 3, fx.term, true, 1,
+               make_snp_install_done_ctx(1, idx_i, 9)) );
+
+    // `J` was not credited, and its transfer is still live and able to report for itself.
+    CHK_EQ( idx_i, s1.fNet->getPeerMatchedIdx(s1.raftServer.get(), 3) );
+    CHK_TRUE( s1.fNet->hasPeerSnapshotSyncCtx(s1.raftServer.get(), 3) );
+    CHK_EQ( idx_j,
+            s1.fNet->getPeerSnapshotSyncCtxLastLogIdx(s1.raftServer.get(), 3) );
+    // `I` really was installed, so it is credited.
+    CHK_EQ( idx_i + 1, s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
+    CHK_EQ( idx_i + 1,
+            s1.fNet->getPeerNextLogIdxFloor(s1.raftServer.get(), 3) );
+
+    print_stats(fx.pkgs);
+    shutdown_late_ack_fixture(fx);
+    return 0;
+}
+
+// Case 5: a follower on the old format sends a one-byte marker with no index. Both outcomes are
+// unchanged from before this fix -- deliberately. The second one is the residue that a carried
+// index cannot fix, because there is nothing to correlate on.
+int late_snapshot_install_ack_legacy_marker_test() {
+    LateAckFixture fx;
+    CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
+    RaftPkg& s1 = *fx.s1;
+
+    ulong next_log_idx = fx.safe_next_log_idx;
+    ulong matched_idx = next_log_idx - 1;
+    ulong floor_idx = next_log_idx - 2;
+
+    // Without a context the response stays uninterpretable, so it is still dropped.
+    reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
+    CHK_Z( arm_pending_resp(s1, "S3") );
+    set_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx);
+    CHK_Z( expire_snapshot_sync_ctx(s1, 3, fx.leader_snp) );
+    CHK_Z( deliver_install_snapshot_resp(
+               s1, "S3", 3, fx.term, true, 1,
+               make_snp_install_done_ctx(0, 0, 1)) );
+
+    CHK_Z( check_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx) );
+
+    // With a context, the marker still completes whatever that context holds -- including pulling
+    // `matched_idx` back to that snapshot. An old follower gives the leader nothing to check that
+    // assumption against.
+    ulong snp_idx = fx.leader_snp->get_last_log_idx();
+    reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
+    CHK_Z( arm_pending_resp(s1, "S3") );
+    set_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx);
+    s1.fNet->setPeerSnapshotInSync(s1.raftServer.get(), 3, fx.leader_snp);
+    CHK_Z( deliver_install_snapshot_resp(
+               s1, "S3", 3, fx.term, true, 1,
+               make_snp_install_done_ctx(0, 0, 1)) );
+
+    CHK_EQ( snp_idx, s1.fNet->getPeerMatchedIdx(s1.raftServer.get(), 3) );
+    CHK_EQ( snp_idx + 1, s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
+    CHK_FALSE( s1.fNet->hasPeerSnapshotSyncCtx(s1.raftServer.get(), 3) );
+
+    print_stats(fx.pkgs);
+    shutdown_late_ack_fixture(fx);
+    return 0;
+}
+
+// Case 6: a payload that is neither the historical marker nor a well-formed extended frame is
+// rejected outright. Falling back to "treat it as the old done-marker" would be the *permissive*
+// reading, because in this code the old marker means completion -- so a malformed acknowledgement
+// would complete whichever install happened to be live.
+int late_snapshot_install_ack_malformed_test() {
+    LateAckFixture fx;
+    CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
+    RaftPkg& s1 = *fx.s1;
+
+    ulong idx_j = fx.leader_snp->get_last_log_idx();
+    ulong next_log_idx = fx.safe_next_log_idx;
+    ulong matched_idx = next_log_idx - 1;
+    ulong floor_idx = next_log_idx - 2;
+
+    struct Malformed {
+        const char* what;
+        uint8_t tag;
+        size_t len;
+    };
+    std::vector<Malformed> cases = {
+        // Long enough to hold an index but tagged as the indexless legacy payload.
+        { "legacy tag with an index-sized payload", 0, 9 },
+        // Claims an index it is too short to contain.
+        { "index tag with a truncated payload", 1, 5 },
+    };
+
+    for (auto& bad: cases) {
+        for (int with_live_ctx = 0; with_live_ctx <= 1; ++with_live_ctx) {
+            _msg("  case: %s, live context: %s\n",
+                 bad.what, with_live_ctx ? "yes" : "no");
+
+            reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
+            CHK_Z( arm_pending_resp(s1, "S3") );
+
+            set_peer_cursor(s1, 3, next_log_idx, matched_idx, floor_idx);
+            CHK_Z( expire_snapshot_sync_ctx(s1, 3, fx.leader_snp) );
+            if (with_live_ctx) {
+                s1.fNet->setPeerSnapshotInSync(
+                    s1.raftServer.get(), 3, fx.leader_snp);
+            }
+
+            CHK_Z( deliver_install_snapshot_resp(
+                       s1, "S3", 3, fx.term, true, 1,
+                       make_snp_install_done_ctx(bad.tag, idx_j, bad.len)) );
+
+            CHK_Z( check_peer_cursor(
+                       s1, 3, next_log_idx, matched_idx, floor_idx) );
+
+            if (with_live_ctx) {
+                // The live transfer survives an unreadable response.
+                CHK_TRUE( s1.fNet->hasPeerSnapshotSyncCtx(
+                              s1.raftServer.get(), 3) );
+                CHK_EQ( idx_j,
+                        s1.fNet->getPeerSnapshotSyncCtxLastLogIdx(
+                            s1.raftServer.get(), 3) );
+            }
+        }
+    }
+
+    print_stats(fx.pkgs);
+    shutdown_late_ack_fixture(fx);
+    return 0;
+}
+
+// Case 7: the index sits at a fixed offset for every tag `>= 1`, so a leader can read it out of a
+// format it does not otherwise understand. That keeps later extensions of this payload additive
+// instead of being rejected by older peers.
+int late_snapshot_install_ack_future_format_test() {
+    LateAckFixture fx;
+    CHK_Z( setup_late_ack_fixture(fx, /*use_bg_thread_for_snapshot_io=*/false) );
+    RaftPkg& s1 = *fx.s1;
+
+    ulong snp_idx = fx.leader_snp->get_last_log_idx();
+
+    for (size_t len: {size_t(9), size_t(17)}) {
+        _msg("  case: unknown tag 2, payload length %zu\n", len);
+
+        reset_peer_for_arming(s1, 3, fx.safe_next_log_idx);
+        CHK_Z( arm_pending_resp(s1, "S3") );
+
+        set_peer_cursor(s1, 3, 1, 0, 0);
+        CHK_Z( expire_snapshot_sync_ctx(s1, 3, fx.leader_snp) );
+        CHK_Z( deliver_install_snapshot_resp(
+                   s1, "S3", 3, fx.term, true, 1,
+                   make_snp_install_done_ctx(2, snp_idx, len)) );
+
+        CHK_EQ( snp_idx + 1,
+                s1.fNet->getPeerNextLogIdx(s1.raftServer.get(), 3) );
+        CHK_EQ( snp_idx, s1.fNet->getPeerMatchedIdx(s1.raftServer.get(), 3) );
+        CHK_EQ( snp_idx + 1,
+                s1.fNet->getPeerNextLogIdxFloor(s1.raftServer.get(), 3) );
+    }
+
+    print_stats(fx.pkgs);
+    shutdown_late_ack_fixture(fx);
+    return 0;
+}
+
 } // namespace snapshot_test
 using namespace snapshot_test;
 
@@ -2455,6 +3015,30 @@ int main(int argc, char* argv[]) {
 
     ts.doTest( "snapshot user ctx deferred free test",
                snapshot_user_ctx_deferred_free_test );
+
+    ts.doTest( "late snapshot install ack accepted test",
+               late_snapshot_install_ack_accepted_test );
+
+    ts.doTest( "late snapshot install ack monotonic test",
+               late_snapshot_install_ack_monotonic_test );
+
+    ts.doTest( "late snapshot install ack no reinstall test",
+               late_snapshot_install_ack_no_reinstall_test );
+
+    ts.doTest( "late snapshot install ack validation test",
+               late_snapshot_install_ack_validation_test );
+
+    ts.doTest( "late snapshot install ack wrong snapshot test",
+               late_snapshot_install_ack_wrong_snapshot_test );
+
+    ts.doTest( "late snapshot install ack legacy marker test",
+               late_snapshot_install_ack_legacy_marker_test );
+
+    ts.doTest( "late snapshot install ack malformed test",
+               late_snapshot_install_ack_malformed_test );
+
+    ts.doTest( "late snapshot install ack future format test",
+               late_snapshot_install_ack_future_format_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");


### PR DESCRIPTION
## Problem

A leader silently discards a follower's **successful** snapshot-install acknowledgement whenever the install takes longer than `snapshot_sync_ctx_timeout`, and then has no record that the follower holds the snapshot at all. The follower is fully caught up and says so; the leader does not believe it.

This is not a rare race. The timeout is a per-round-trip responsiveness budget — its own doc comment says *"if a single snapshot syncing request exceeds this"*, and `snapshot_sync_ctx::set_offset` resets the timer on every offset advance — and it defaults to `raft_limits_response_limit * heart_beat_interval_`. But the final round trip of a logical-object install contains the state machine's `apply_snapshot`, which is indivisible, so no `snapshot_transfer_chunk_size` can bring that round trip under a responsiveness budget. Measured on a production ClickHouse Keeper ensemble against a 10 s derived budget:

| snapshot | chunks | transfer | apply | timed out |
| --- | --- | --- | --- | --- |
| 254.8 MB | 1 | 2 s | 14 s | yes, 10002 ms |
| 400.9 MB | 1 | 3 s | 17 s | yes, 10000 ms |
| 418.6 MB | **4** | 11 s | 19 s | yes, 10851 ms |

The third row is the load-bearing one: chunking was active and bounded each transfer round trip to a few seconds, and the timeout still fired *inside* the 19 s apply.

Concrete consequences, all observed on that ensemble:

- The leader logs `snapshot install task for peer N timed out: 10000 ms, reset snapshot sync context`, immediately followed by `no snapshot sync context for this peer, drop the response` — even though the follower logged `successfully receive a snapshot` and applied it.
- `next_log_idx`, `matched_idx` and in particular `next_log_idx_floor` are never set from the installed snapshot, so **nothing bounds a subsequent backward log walk**. On builds without #109 the leader then rewinds one index per round trip, logging `declined append: peer N, prev next log idx ..., resp next ...` repeatedly. On builds with #109 the walk is absorbed in the same second via `peer N compacted snapshot boundary`, but the wasted install still happens.
- The follower stayed out of quorum for **17.5 minutes, twice within one hour**, producing roughly 10.8M client `Session expired` errors.
- Because `matched_idx` is never set, the peer does not count toward the commit quorum for that whole interval.
- If the leader has since produced a newer snapshot, the peer is sent a **second full install** of it. The timeout does not clear `snapshot_sync_is_needed`, and a follower answering `RECEIVING_SNAPSHOT` while applying is exactly what sets that flag.

## Root cause

`raft_server::handle_hb_timeout` → `request_append_entries` calls `check_snapshot_timeout` (`src/handle_snapshot_sync.cxx`), which on expiry calls `clear_snapshot_sync_ctx` and destroys the peer's `snapshot_sync_ctx`. When the follower's terminal response finally arrives, `handle_peer_resp` dispatches it to `raft_server::handle_install_snapshot_resp`, which finds `p->get_snapshot_sync_ctx() == nullptr` and returns after logging the drop — so the three writes on the success path, all of which read `sync_ctx->get_snapshot()->get_last_log_idx()`, never run.

The drop itself is *correct given the information available*, which is why it has survived: `resp_msg` carries `term`/`src`/`next_idx`/`accepted`/`ctx` and **not** the installed snapshot's Raft index. For `logical_object` snapshots — what ClickHouse Keeper sends via `KeeperStateMachine::read_logical_snp_obj` — `next_idx` is an object cursor and the terminal `ctx` is a bare done flag: a single zero byte written in `handle_install_snapshot_req`. The index exists only inside `sync_ctx`. Without it the response is genuinely uninterpretable, and binding a peer to the wrong snapshot on unverifiable information would be worse than dropping. So the defect is not the timeout and not the drop — it is that the acknowledgement is not self-describing.

## Fix

Make the acknowledgement carry the one thing the leader's completion bookkeeping actually needs from the context: the installed snapshot's `last_log_idx`. The new `snp_install_done_ctx` in `src/handle_snapshot_sync.cxx` owns the format, the follower emits it at the single genuinely successful terminal site in `handle_install_snapshot_req`, and the leader reads it in `handle_install_snapshot_resp`:

```
Format tag                       1 byte
Installed snapshot last_log_idx  8 bytes (little endian)
```

`len == 1` with tag `0` remains the historical indexless marker. For every tag `>= 1`, bytes 1..8 are the index — fixing that prefix lets a leader read the index out of a tag it does not otherwise understand, so later extensions stay additive. Anything else is malformed and is **rejected** rather than read as a completion: falling back to "treat it as the old marker" would be the *permissive* reading here, because in this code the old marker *means* completion.

All parsing happens inside the `resp.get_accepted()` path and nowhere else, so rejected responses keep their current behaviour verbatim — that branch deliberately rewrites the peer's position and zeroes the floor as follower-ahead recovery, which must not be disturbed. Within the accepted path:

- **With no sync context**, an acknowledgement carrying an index is acted upon instead of dropped, provided the index passes validation: the response term is current, the index lies in `(0, precommit_index_]`, and `idx + 1` cannot wrap. Every write is monotone (`max`), so a late acknowledgement can never move a peer backwards — that is what makes acting without the context safe at all. The rest of the success bookkeeping runs too, including clearing `snapshot_sync_is_needed`; without that last part the fix would save little, since `create_append_entries_req` would start another full install as soon as the leader held a newer snapshot.
- **With a sync context whose snapshot has a different index**, the in-flight install is no longer treated as done. `matched_idx` feeds `get_expected_committed_log_idx`, so crediting a peer with a snapshot it never installed is a safety problem and not merely bookkeeping. Only the index that really was installed is credited, monotonically, and the live transfer is left to finish and report for itself.

The timeout is not removed and the drop is not made unconditional. Some timeout must exist, because `clear_snapshot_sync_ctx` → `destroy_user_snp_ctx` is what releases the state machine's user snapshot context; holding that open indefinitely for a possibly-dead follower would leak. This change only makes the drop a fallback instead of the normal outcome.

Eight cases were added to `tests/unit/snapshot_test.cxx`: `late_snapshot_install_ack_accepted_test`, `..._monotonic_test`, `..._no_reinstall_test`, `..._validation_test`, `..._wrong_snapshot_test`, `..._legacy_marker_test`, `..._malformed_test` and `..._future_format_test`. Five fail without this change (accepted, no-reinstall, wrong-snapshot, malformed, future-format), verified by reverting `src/handle_snapshot_sync.cxx` while keeping the tests; the other three pass on the unpatched code because it drops the acknowledgement or is unchanged by design, so they guard the new logic rather than reproduce the defect. The pre-existing suites are what guarantee the untouched paths still hold — in particular `snapshot_basic_test`, `snapshot_new_member_restart_test` and `snapshot_leader_switch_test` cover normal, timely installs, and `snapshot_rewind_floor_test` covers the #109 floor clamping that this change now feeds a non-zero floor into. All pass with `cmake -DDISABLE_ASIO=1`: `snapshot_test` 33/33, `raft_server_test` 26/26, `leader_election_test` 9/9, `learner_new_joiner_test` 4/4, `failure_test` 7/7, `serialization_test` 11/11, `buffer_test` 5/5. The change was also built and run inside ClickHouse — 177/177 Keeper and coordination unit tests.

`raft_server_handler` and `FakeNetwork` gain accessors so the tests drive the real `check_snapshot_timeout` and read `precommit_index_` rather than emulating the post-timeout state.

## Compatibility

Degrades safely in both directions, which matters because the incident happened during a mixed-version rollout:

| direction | behaviour |
| --- | --- |
| new follower → old leader | an old leader's completion test for logical-object snapshots is only that `resp_msg::get_ctx` is non-null, and it never inspects the payload, so a 9-byte context is still read as done |
| old follower → new leader | a 1-byte tag-`0` context takes the legacy row above and behaves exactly as before |

## Deliberately not addressed

- **Legacy acknowledgements carry no index**, so an old follower plus a live sync context still cannot be correlated. That needs a different mechanism — an echoed request id, or a generation counter on the sync context.
- **`raw_binary` snapshots**, whose completion test is `resp.get_next_idx() >= snp->size()` and needs the snapshot object regardless.
- **`handle_install_snapshot_resp_new_member`**, the add-server path, which has the identical shape. The follower emits the extended payload there too, which is harmless because that handler ignores the payload.

## Question for reviewers

Is extending the terminal `ctx` acceptable, or would you prefer a dedicated `resp_msg` field or a `flags` bit? The compatibility argument above depends on the current completion test staying "non-null only", and you may reasonably want that invariant made explicit rather than relied upon.

Related: https://github.com/ClickHouse/NuRaft/pull/109
Related: https://github.com/ClickHouse/NuRaft/pull/118
Related: https://github.com/ClickHouse/ClickHouse/pull/112405
