### PR TITLE
Send the log-sync request to a joining server under async snapshot IO

### DIFF
--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -356,20 +356,12 @@ void raft_server::sync_log_to_new_srv(ulong start_idx) {
     }
 
     if (req) {
-        // Send whatever was built above. The snapshot branch leaves `req` null only
-        // when asynchronous snapshot IO is on, having handed the work to the IO
-        // thread; in every other case -- including the log-pack branch in BOTH IO
-        // modes -- there is a request here and it has to go out.
-        //
-        // Keying this on `use_bg_thread_for_snapshot_io_` instead dropped the
-        // log-pack request whenever asynchronous snapshot IO was enabled. Nothing
-        // enqueues a log pack with `snapshot_io_mgr`, so invoking the thread did not
-        // send it, the catch-up loop waited for a response that could not arrive,
-        // and the joining server never joined.
+        // Dispatch on what was built, not on the IO mode: only the snapshot branch
+        // defers to the IO thread, and nothing enqueues a log pack with
+        // `snapshot_io_mgr`, so keying this on the mode dropped the log-pack request.
         srv_to_join_->send_req(srv_to_join_, req, ex_resp_handler_);
     } else if (params->use_bg_thread_for_snapshot_io_) {
-        // Asynchronous snapshot IO: `create_sync_snapshot_req` has queued the read,
-        // and the IO thread builds and sends the request.
+        // `create_sync_snapshot_req` queued the read; the IO thread sends it.
         snapshot_io_mgr::instance().invoke();
     }
 }

--- a/src/handle_join_leave.cxx
+++ b/src/handle_join_leave.cxx
@@ -355,11 +355,21 @@ void raft_server::sync_log_to_new_srv(ulong start_idx) {
               ( state_->get_term(), log_pack, log_val_type::log_pack) );
     }
 
-    if (!params->use_bg_thread_for_snapshot_io_) {
-        // Synchronous IO: directly send here.
+    if (req) {
+        // Send whatever was built above. The snapshot branch leaves `req` null only
+        // when asynchronous snapshot IO is on, having handed the work to the IO
+        // thread; in every other case -- including the log-pack branch in BOTH IO
+        // modes -- there is a request here and it has to go out.
+        //
+        // Keying this on `use_bg_thread_for_snapshot_io_` instead dropped the
+        // log-pack request whenever asynchronous snapshot IO was enabled. Nothing
+        // enqueues a log pack with `snapshot_io_mgr`, so invoking the thread did not
+        // send it, the catch-up loop waited for a response that could not arrive,
+        // and the joining server never joined.
         srv_to_join_->send_req(srv_to_join_, req, ex_resp_handler_);
-    } else {
-        // Asynchronous IO: invoke the thread.
+    } else if (params->use_bg_thread_for_snapshot_io_) {
+        // Asynchronous snapshot IO: `create_sync_snapshot_req` has queued the read,
+        // and the IO thread builds and sends the request.
         snapshot_io_mgr::instance().invoke();
     }
 }

--- a/tests/unit/learner_new_joiner_test.cxx
+++ b/tests/unit/learner_new_joiner_test.cxx
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "debugging_options.hxx"
 #include "fake_network.hxx"
+#include "fake_executer.hxx"
 #include "raft_package_fake.hxx"
 
 #include "raft_params.hxx"
@@ -423,6 +424,86 @@ int learner_to_normal_test() {
 }  // namespace learner_new_joiner_test;
 using namespace learner_new_joiner_test;
 
+// A server joining a cluster must be sent its log pack even when asynchronous
+// snapshot IO is enabled.
+//
+// `sync_log_to_new_srv` builds either a snapshot request or a log-pack
+// `sync_log_request`, then used to send it only when asynchronous snapshot IO
+// was OFF, invoking the snapshot IO thread instead. Nothing enqueues a log pack
+// with that thread, so the request was dropped, the leader's catch-up loop
+// waited for a response that could not arrive, and the configuration was never
+// committed -- the joining server never joined.
+//
+// Retains all logs and pushes the snapshot out of reach, so the join is served
+// from the LOG rather than from a snapshot: that is the branch under test.
+int log_sync_with_async_snapshot_io_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    RaftPkg s1(f_base, 1, "S1");
+    RaftPkg s2(f_base, 2, "S2");
+    RaftPkg s3(f_base, 3, "S3");
+    std::vector<RaftPkg*> pkgs_old = {&s1, &s2};
+    std::vector<RaftPkg*> pkgs_new = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers( pkgs_new ) );
+    CHK_Z( make_group( pkgs_old ) );
+
+    // The state machines need a driver: without one, wait_for_sm_exec below never
+    // returns.
+    ExecArgs exec_args(&s1);
+    TestSuite::ThreadHolder hh(&exec_args, fake_executer, fake_executer_killer);
+
+    for (auto& entry: pkgs_new) {
+        raft_params param = entry->raftServer->get_current_params();
+        param.return_method_ = raft_params::async_handler;
+        param.use_bg_thread_for_snapshot_io_ = true;
+        param.reserved_log_items_ = 1000000;
+        param.snapshot_distance_ = 1000000;
+        entry->raftServer->update_params(param);
+    }
+
+    for (size_t ii = 0; ii < 10; ++ii) {
+        std::string test_msg = "test" + std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        ptr< cmd_result< ptr<buffer> > > ret = s1.raftServer->append_entries( {msg} );
+        CHK_TRUE( ret->get_accepted() );
+        s1.fNet->execReqResp();
+        s1.fNet->execReqResp();
+    }
+    CHK_Z( wait_for_sm_exec(pkgs_old, COMMIT_TIMEOUT_SEC) );
+
+    const uint64_t leader_last = s1.raftServer->get_last_log_idx();
+    CHK_GT( leader_last, (uint64_t)0 );
+
+    s1.raftServer->add_srv( *(s3.getTestMgr()->get_srv_config()) );
+    for (int ii = 0; ii < 20; ++ii) {
+        s1.fNet->execReqResp();
+    }
+    wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC);
+    for (int ii = 0; ii < 20; ++ii) {
+        s1.fNet->execReqResp();
+    }
+    wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC);
+
+    // The joining server must actually have joined. Asserting that it merely made
+    // some progress is not enough: on the unfixed build it still receives the
+    // initial configuration entry and sits at log index 1, while the leader is at
+    // 12 and the new server is absent from the cluster configuration.
+    CHK_NONNULL( s1.raftServer->get_srv_config(3).get() );
+    CHK_GTEQ( s3.raftServer->get_last_log_idx(), leader_last - 1 );
+
+    s1.raftServer->shutdown();
+    s2.raftServer->shutdown();
+    s3.raftServer->shutdown();
+    fake_executer_killer(&exec_args);
+    hh.join();
+    CHK_Z( hh.getResult() );
+    f_base->destroy();
+    return 0;
+}
+
 int main(int argc, char** argv) {
     TestSuite ts(argc, argv);
 
@@ -442,6 +523,9 @@ int main(int argc, char** argv) {
 
     ts.doTest( "learner to normal test",
                learner_to_normal_test );
+
+    ts.doTest( "log sync with async snapshot io test",
+               log_sync_with_async_snapshot_io_test );
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");

--- a/tests/unit/learner_new_joiner_test.cxx
+++ b/tests/unit/learner_new_joiner_test.cxx
@@ -425,17 +425,10 @@ int learner_to_normal_test() {
 using namespace learner_new_joiner_test;
 
 // A server joining a cluster must be sent its log pack even when asynchronous
-// snapshot IO is enabled.
+// snapshot IO is enabled; that request used to be dropped in that mode.
 //
-// `sync_log_to_new_srv` builds either a snapshot request or a log-pack
-// `sync_log_request`, then used to send it only when asynchronous snapshot IO
-// was OFF, invoking the snapshot IO thread instead. Nothing enqueues a log pack
-// with that thread, so the request was dropped, the leader's catch-up loop
-// waited for a response that could not arrive, and the configuration was never
-// committed -- the joining server never joined.
-//
-// Retains all logs and pushes the snapshot out of reach, so the join is served
-// from the LOG rather than from a snapshot: that is the branch under test.
+// Retains all logs and pushes the snapshot out of reach so the join is served
+// from the LOG rather than from a snapshot -- that is the branch that was broken.
 int log_sync_with_async_snapshot_io_test() {
     reset_log_files();
     ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
@@ -487,10 +480,9 @@ int log_sync_with_async_snapshot_io_test() {
     }
     wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC);
 
-    // The joining server must actually have joined. Asserting that it merely made
-    // some progress is not enough: on the unfixed build it still receives the
-    // initial configuration entry and sits at log index 1, while the leader is at
-    // 12 and the new server is absent from the cluster configuration.
+    // Must actually have JOINED. "Made some progress" would not fail against the
+    // unfixed code, which still delivers the initial configuration entry and leaves
+    // the server at index 1, absent from the cluster configuration.
     CHK_NONNULL( s1.raftServer->get_srv_config(3).get() );
     CHK_GTEQ( s3.raftServer->get_last_log_idx(), leader_last - 1 );
 


### PR DESCRIPTION
## Problem

With `use_bg_thread_for_snapshot_io_` enabled, a server added to the cluster never joins. The leader's catch-up loop waits forever for a response that cannot arrive, so the configuration change is never committed.

Observed on the unfixed build: the new server is absent from the cluster configuration and stuck at log index 1, while the leader is at 12.

## Root cause

`sync_log_to_new_srv` builds one of two requests — a snapshot request when the peer is below the retained log, or a log-pack `sync_log_request` otherwise — and then decides how to dispatch it:

```cpp
if (!params->use_bg_thread_for_snapshot_io_) {
    srv_to_join_->send_req(srv_to_join_, req, ex_resp_handler_);
} else {
    snapshot_io_mgr::instance().invoke();
}
```

The dispatch is keyed on the IO mode, but only the *snapshot* branch defers to the IO thread. Nothing ever enqueues a log pack with `snapshot_io_mgr` — `create_sync_snapshot_req` is the only producer — so with async snapshot IO on, invoking the thread does not send the log-pack request. It is simply dropped.

Synchronous IO is unaffected, which is why this has gone unnoticed: `use_bg_thread_for_snapshot_io_` is off by default.

## Fix

Dispatch on what was actually built rather than on the IO mode. The snapshot branch leaves `req` null exactly when it has handed the work to the IO thread; in every other case — including the log-pack branch in *both* IO modes — there is a request and it has to go out.

## Test

`log_sync_with_async_snapshot_io_test` in `learner_new_joiner_test`. It retains all logs and pushes `snapshot_distance_` out of reach so the join is served from the log rather than from a snapshot, which is the branch that was broken.

It asserts that the new server reaches the cluster configuration and catches up to the leader. Asserting that it merely made *some* progress would not do: the unfixed code still delivers the initial configuration entry, so the joining server sits at index 1 and a "greater than zero" check passes.

Verified both ways against the exact pre-patch code: with the fix 5/5 pass, without it the four existing tests still pass and only the new one fails.

## Provenance

Found while investigating a Keeper incident where a lagging follower's catch-up read from object storage stalled the leader. Enabling async snapshot IO was being considered as a mitigation — moving the snapshot read off the Raft lock — and doing so surfaced this. The fix is independent of that work and stands on its own.