### PR TITLE
Check the commit waits in `log_sync_with_async_snapshot_io_test`

### DIFF
--- a/tests/unit/learner_new_joiner_test.cxx
+++ b/tests/unit/learner_new_joiner_test.cxx
@@ -474,11 +474,11 @@ int log_sync_with_async_snapshot_io_test() {
     for (int ii = 0; ii < 20; ++ii) {
         s1.fNet->execReqResp();
     }
-    wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC);
+    CHK_Z( wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC) );
     for (int ii = 0; ii < 20; ++ii) {
         s1.fNet->execReqResp();
     }
-    wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC);
+    CHK_Z( wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC) );
 
     // Must actually have JOINED. "Made some progress" would not fail against the
     // unfixed code, which still delivers the initial configuration entry and leaves


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/NuRaft/pull/123, from review feedback on https://github.com/ClickHouse/ClickHouse/pull/114275.

## Problem

Both `wait_for_sm_exec(pkgs_new, COMMIT_TIMEOUT_SEC)` calls in `log_sync_with_async_snapshot_io_test` ignored their return value. They are the only two such calls in the file — the other twelve are wrapped in `CHK_Z`, including the same "pump `execReqResp`, then wait on `pkgs_new` after `add_srv`" shape used by `new_joiner_take_over_test`.

`wait_for_sm_exec` compares `get_committed_log_idx` against `get_target_committed_log_idx`, so swallowing a timeout let a joiner that appended the synced log pack but never applied it pass the test: the surviving assertions check the leader's view of the configuration and S3's log store, neither of which observes applied state.

## Solution

Wrap both calls in `CHK_Z`, matching every other call site in the file.

## Verification

| | |
|---|---|
| Before the change | 5/5 pass, this test 161.2 ms |
| After the change | 5/5 pass, this test 161.5 ms |
| After the change, with `sync_log_to_new_srv` reverted to the pre-#123 code | 4 pass / 1 fail — the regression proof is intact |

Two properties worth recording:

- **The discriminator is unchanged.** Against the pre-patch code the test still fails on `CHK_NONNULL( s1.raftServer->get_srv_config(3).get() )`, and neither new `CHK_Z` fires: S3 receives nothing, so its target commit index never advances and `wait_for_sm_exec` returns immediately. The added checks are extra coverage, not a replacement.
- **No new timing dependency.** The runtime is unchanged, which shows both waits already succeeded rather than timing out, so `CHK_Z` cannot make the test slower or flakier.