### PR TITLE
slow member backpressure via 4lw

### DIFF
--- a/include/libnuraft/peer.hxx
+++ b/include/libnuraft/peer.hxx
@@ -86,6 +86,7 @@ public:
         , last_streamed_log_idx_(0)
         , bytes_in_flight_(0)
         , snapshot_sync_is_needed_(false)
+        , out_of_log_range_(false)
         , self_mark_down_(false)
         , l_(logger)
     {
@@ -446,6 +447,13 @@ public:
         return snapshot_sync_is_needed_;
     }
 
+    void set_out_of_log_range(bool to) {
+        out_of_log_range_ = to;
+    }
+    bool is_out_of_log_range() const {
+        return out_of_log_range_;
+    }
+
     bool is_self_mark_down() const {
         return self_mark_down_;
     }
@@ -721,6 +729,15 @@ private:
      * `next_log_idx_` is within the range, we should send a snapshot.
      */
     std::atomic<bool> snapshot_sync_is_needed_;
+
+    /**
+     * Set to `true` when the leader found that it can send this peer neither
+     * the log entries it needs nor a snapshot, and warned it that it is out
+     * of the leader's log range. Such a peer cannot be recovered by
+     * replication at all, so anything that waits for peers to catch up has to
+     * leave it out. Cleared as soon as the leader can serve it again.
+     */
+    std::atomic<bool> out_of_log_range_;
 
     /**
      * If `true`, this peer marks itself down.

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -674,9 +674,10 @@ public:
      * is waited for however far behind it is, including while it receives a
      * snapshot. It is left out only when waiting cannot get it anywhere: the
      * leader cannot reach it, it made no progress within
-     * `slow_member_backpressure_no_progress_timeout_`, or it has not answered
-     * at all yet on a new connection and no snapshot is on its way to it
-     * either, which leaves the leader with no idea where it stands.
+     * `slow_member_backpressure_no_progress_timeout_`, it has not answered at
+     * all yet on a new connection and no snapshot is on its way to it either,
+     * or it is out of the leader's log range and cannot be recovered by
+     * replication at all.
      *
      * While this is on, writes go at the speed of the slowest member, so it is
      * off by default and meant to be switched on for a while and switched off

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -100,6 +100,8 @@ struct raft_params {
         , use_new_joiner_type_(false)
         , use_bg_thread_for_snapshot_io_(false)
         , use_full_consensus_among_healthy_members_(false)
+        , slow_member_backpressure_enabled_(false)
+        , slow_member_backpressure_max_uncommitted_(0)
         , track_peers_sm_commit_idx_(false)
         , parallel_log_appending_(false)
         , max_log_gap_in_stream_(0)
@@ -662,6 +664,31 @@ public:
      * from the leader for a configured time (`full_consensus_follower_limit_`).
      */
     bool use_full_consensus_among_healthy_members_;
+
+    /**
+     * (Experimental)
+     * If `true`, the leader does not commit an entry before every member that
+     * it can reach has it, so that a member which fell behind can catch up.
+     * Unlike `use_full_consensus_among_healthy_members_`, a member is waited
+     * for however far behind it is, including while it receives a snapshot; a
+     * member is left out only when the leader cannot reach it at all.
+     *
+     * While this is on, writes go at the speed of the slowest member, so it is
+     * off by default and meant to be switched on for a while and switched off
+     * again, with `request_slow_member_backpressure`. It lasts for one
+     * leadership: a new leader switches it off.
+     */
+    bool slow_member_backpressure_enabled_;
+
+    /**
+     * (Experimental)
+     * The value `max_uncommitted_log_entries_` takes while
+     * `slow_member_backpressure_enabled_` is on. Holding the commit index back
+     * does not by itself stop the leader from taking new writes, so without a
+     * tighter limit the log keeps growing and the member falls even further
+     * behind. `0` leaves the limit unchanged.
+     */
+    uint64_t slow_member_backpressure_max_uncommitted_;
 
     /**
      * (Experimental)

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -668,16 +668,19 @@ public:
 
     /**
      * (Experimental)
-     * If `true`, the leader does not commit an entry before every member that
-     * it can reach has it, so that a member which fell behind can catch up.
-     * Unlike `use_full_consensus_among_healthy_members_`, a member is waited
-     * for however far behind it is, including while it receives a snapshot; a
-     * member is left out only when the leader cannot reach it at all.
+     * If `true`, the leader does not commit an entry before every member it
+     * is still waiting for has it, so that a member which fell behind can
+     * catch up. Unlike `use_full_consensus_among_healthy_members_`, a member
+     * is waited for however far behind it is, including while it receives a
+     * snapshot. It is left out only when waiting cannot get it anywhere: the
+     * leader cannot reach it, or it made no progress within
+     * `slow_member_backpressure_no_progress_timeout_`.
      *
      * While this is on, writes go at the speed of the slowest member, so it is
      * off by default and meant to be switched on for a while and switched off
      * again, with `request_slow_member_backpressure`. It lasts for one
-     * leadership: a new leader switches it off.
+     * leadership: it is switched off both when a server becomes the leader and
+     * when it stops being one.
      */
     bool slow_member_backpressure_enabled_;
 

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -101,6 +101,7 @@ struct raft_params {
         , use_bg_thread_for_snapshot_io_(false)
         , use_full_consensus_among_healthy_members_(false)
         , slow_member_backpressure_enabled_(false)
+        , slow_member_backpressure_no_progress_timeout_(30 * 1000)
         , slow_member_backpressure_max_uncommitted_(0)
         , track_peers_sm_commit_idx_(false)
         , parallel_log_appending_(false)
@@ -679,6 +680,23 @@ public:
      * leadership: a new leader switches it off.
      */
     bool slow_member_backpressure_enabled_;
+
+    /**
+     * (Experimental)
+     * How long, in millisecond, the leader keeps waiting for a member that
+     * makes no progress at all, before leaving it behind. Progress means an
+     * accepted response: log entries taken, or a snapshot object saved. A
+     * member that is merely slow keeps resetting this, so only one that is
+     * stuck stops being waited for.
+     *
+     * Give it room. A member applying a large snapshot can be quiet for a
+     * long time, and it is exactly the member the backpressure exists for.
+     * A member the leader cannot reach at all is dropped straight away, by
+     * its failed requests, without waiting for this.
+     *
+     * `0` means the leader never stops waiting for a member it can reach.
+     */
+    int32 slow_member_backpressure_no_progress_timeout_;
 
     /**
      * (Experimental)

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -673,8 +673,10 @@ public:
      * catch up. Unlike `use_full_consensus_among_healthy_members_`, a member
      * is waited for however far behind it is, including while it receives a
      * snapshot. It is left out only when waiting cannot get it anywhere: the
-     * leader cannot reach it, or it made no progress within
-     * `slow_member_backpressure_no_progress_timeout_`.
+     * leader cannot reach it, it made no progress within
+     * `slow_member_backpressure_no_progress_timeout_`, or it has not answered
+     * at all yet on a new connection and no snapshot is on its way to it
+     * either, which leaves the leader with no idea where it stands.
      *
      * While this is on, writes go at the speed of the slowest member, so it is
      * off by default and meant to be switched on for a while and switched off

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -101,7 +101,7 @@ struct raft_params {
         , use_bg_thread_for_snapshot_io_(false)
         , use_full_consensus_among_healthy_members_(false)
         , slow_member_backpressure_enabled_(false)
-        , slow_member_backpressure_no_progress_timeout_(30 * 1000)
+        , slow_member_backpressure_no_progress_timeout_(5 * 60 * 1000)
         , slow_member_backpressure_max_uncommitted_(0)
         , track_peers_sm_commit_idx_(false)
         , parallel_log_appending_(false)
@@ -692,10 +692,12 @@ public:
      * member that is merely slow keeps resetting this, so only one that is
      * stuck stops being waited for.
      *
-     * Give it room. A member applying a large snapshot can be quiet for a
-     * long time, and it is exactly the member the backpressure exists for.
-     * A member the leader cannot reach at all is dropped straight away, by
-     * its failed requests, without waiting for this.
+     * The default is five minutes, and it is meant to be that large. A
+     * member applying a large snapshot can be quiet for minutes, and it is
+     * exactly the member the backpressure exists for; a timeout in seconds
+     * would abandon it just as waiting started to pay off. A member the
+     * leader cannot reach at all is dropped straight away, by its failed
+     * requests, without waiting for this.
      *
      * `0` means the leader never stops waiting for a member it can reach.
      */

--- a/include/libnuraft/raft_params.hxx
+++ b/include/libnuraft/raft_params.hxx
@@ -679,6 +679,12 @@ public:
      * or it is out of the leader's log range and cannot be recovered by
      * replication at all.
      *
+     * Only regular members are waited for. A learner is not, because the
+     * commit index is decided by the members that vote, and holding it for a
+     * member that does not vote is a different bargain from the one this
+     * setting offers. A learner can therefore still drift until it needs a
+     * snapshot while this is on.
+     *
      * While this is on, writes go at the speed of the slowest member, so it is
      * off by default and meant to be switched on for a while and switched off
      * again, with `request_slow_member_backpressure`. It lasts for one

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -138,6 +138,8 @@ public:
             leave_limit_ = src.leave_limit_.load();
             vote_limit_ = src.vote_limit_.load();
             busy_connection_limit_ = src.busy_connection_limit_.load();
+            full_consensus_leader_limit_ = src.full_consensus_leader_limit_.load();
+            full_consensus_follower_limit_ = src.full_consensus_follower_limit_.load();
             return *this;
         }
 
@@ -467,6 +469,26 @@ public:
      *         the next leader due to various failures.
      */
     bool request_leadership(int successor_id = -1);
+
+    /**
+     * Ask the current leader to turn the slow member backpressure on or off
+     * while the server is running. It makes the leader hold the commit index
+     * back for a member that has fallen behind. Only the setting on the leader
+     * has an effect.
+     *
+     * If this server is the leader, it applies the setting at once. A follower
+     * sends the request to the leader. The leader then sends the setting to
+     * its peers, best-effort: a peer that is busy or down can miss it. Read
+     * the value on each node with `get_current_params` to see what it is.
+     *
+     * The setting lasts for one leadership. A new leader switches it off, so
+     * it has to be turned on again after a leader change.
+     *
+     * @param enable If `true`, turn the backpressure on.
+     * @return `true` if the request was applied locally or sent to the leader,
+     *         which does not guarantee that the leader applied it.
+     */
+    bool request_slow_member_backpressure(bool enable);
 
     /**
      * Start the election timer on this server, if this server is a follower.
@@ -1058,6 +1080,23 @@ protected:
     std::list<ptr<peer>> get_not_responding_peers(int expiry = 0);
     size_t get_not_responding_peers_count(int expiry = 0, uint64_t required_log_idx = 0);
     size_t get_num_stale_peers();
+    uint64_t apply_slow_member_backpressure(uint64_t expected_commit_index);
+
+    /**
+     * The limit of uncommitted log entries that is really in use. While
+     * `slow_member_backpressure_enabled_` is on it is the tighter of
+     * `max_uncommitted_log_entries_` and
+     * `slow_member_backpressure_max_uncommitted_`, where `0` means no limit.
+     */
+    uint64_t get_max_uncommitted_log_entries() const;
+
+    /**
+     * Limits how often the slow member backpressure writes a log message, in
+     * microsecond. The first message is always written: it is the one that
+     * tells an operator the leader is throttling.
+     */
+    timer_helper slow_member_backpressure_log_timer_{5 * 1000 * 1000, true};
+
     static bool is_excluded_from_quorum(const peer& pp,
                                         int32_t resp_elapsed_ms,
                                         int32_t expiry,
@@ -1096,7 +1135,15 @@ protected:
     ptr<resp_msg> handle_priority_change_req_v2(req_msg& req);
     ptr<resp_msg> handle_reconnect_req(req_msg& req);
     ptr<resp_msg> handle_custom_notification_req(req_msg& req);
+    ptr<resp_msg> handle_slow_member_backpressure_request
+                  ( req_msg& req,
+                    ptr<custom_notification_msg> msg,
+                    ptr<resp_msg> resp );
     ptr<resp_msg> handle_leader_status_req(req_msg& req);
+
+    ptr<req_msg> create_slow_member_backpressure_req(int dst, bool enable);
+    void switch_slow_member_backpressure(bool enable);
+    void broadcast_slow_member_backpressure(bool enable);
 
     void handle_join_cluster_resp(resp_msg& resp);
     void handle_log_sync_resp(resp_msg& resp);

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -477,12 +477,12 @@ public:
      * has an effect.
      *
      * If this server is the leader, it applies the setting at once. A follower
-     * sends the request to the leader. The leader then sends the setting to
-     * its peers, best-effort: a peer that is busy or down can miss it. Read
-     * the value on each node with `get_current_params` to see what it is.
+     * sends the request to the leader and does not set it locally, so only the
+     * leader ever holds it: read it with `get_current_params` on the leader.
      *
-     * The setting lasts for one leadership. A new leader switches it off, so
-     * it has to be turned on again after a leader change.
+     * The setting lasts for one leadership. It is switched off both when a
+     * server becomes the leader and when it stops being the leader, so it has
+     * to be turned on again after a leader change.
      *
      * @param enable If `true`, turn the backpressure on.
      * @return `true` if the request was applied locally or sent to the leader,
@@ -1143,7 +1143,6 @@ protected:
 
     ptr<req_msg> create_slow_member_backpressure_req(int dst, bool enable);
     void switch_slow_member_backpressure(bool enable);
-    void broadcast_slow_member_backpressure(bool enable);
 
     void handle_join_cluster_resp(resp_msg& resp);
     void handle_log_sync_resp(resp_msg& resp);

--- a/include/libnuraft/raft_server.hxx
+++ b/include/libnuraft/raft_server.hxx
@@ -1179,6 +1179,11 @@ protected:
     void reset_srv_to_join();
     void reset_srv_to_leave();
     ptr<req_msg> create_append_entries_req(ptr<peer>& pp, ulong custom_last_log_idx = 0);
+    ptr<req_msg> create_out_of_log_range_req(peer& p,
+                                             ulong term,
+                                             ulong last_log_idx,
+                                             ulong commit_idx,
+                                             ulong starting_idx);
     ptr<req_msg> create_sync_snapshot_req(ptr<peer>& pp,
                                           ulong last_log_idx,
                                           ulong term,

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -738,6 +738,13 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
 
     if (params->use_full_consensus_among_healthy_members_) {
         // Full consensus mode: set flag indicating the member is excluded.
+        //
+        // NOTE: Unlike `get_expected_committed_log_idx`, this is not gated on
+        //       `custom_commit_quorum_size_ == 0`. So when a custom quorum
+        //       size is set, the leader commits by that quorum, but it still
+        //       tells a member that full consensus would have left it out.
+        //       This is the safer of the two mistakes: without the flag every
+        //       member would believe that it belongs to the quorum.
         uint64_t last_resp_time_ms = p.get_resp_timer_us() / 1000;
         uint64_t expiry = params->heart_beat_interval_ *
                           raft_server::raft_limits_.full_consensus_leader_limit_;
@@ -1903,13 +1910,93 @@ ulong raft_server::get_expected_committed_log_idx() {
     }
 
     aci_params.current_commit_index_ = quick_commit_index_;
-    aci_params.expected_commit_index_ = matched_indexes[quorum_idx];
+    aci_params.expected_commit_index_ =
+        apply_slow_member_backpressure(matched_indexes[quorum_idx]);
     uint64_t adjusted_commit_index = state_machine_->adjust_commit_index(aci_params);
     if (aci_params.expected_commit_index_ != adjusted_commit_index) {
         p_tr( "commit index adjusted: %" PRIu64 " -> %" PRIu64,
               aci_params.expected_commit_index_, adjusted_commit_index );
     }
     return adjusted_commit_index;
+}
+
+uint64_t raft_server::apply_slow_member_backpressure(uint64_t expected_commit_index) {
+    ptr<raft_params> params = ctx_->get_params();
+    if (!params->slow_member_backpressure_enabled_) {
+        return expected_commit_index;
+    }
+
+    if (params->custom_commit_quorum_size_) {
+        // The quorum size is overridden on purpose, for example in recovery
+        // mode. Waiting for every member would work against that.
+        return expected_commit_index;
+    }
+
+    // How long a member may stay silent and still count as reachable, reusing
+    // the limit the leader already applies to the same peers for the same
+    // question in `create_append_entries_req`.
+    uint64_t expiry = (uint64_t)params->heart_beat_interval_ *
+                      raft_server::raft_limits_.full_consensus_leader_limit_;
+    uint64_t clamped_commit_index = expected_commit_index;
+    int32 slowest_member = -1;
+
+    for (auto& entry: peers_) {
+        ptr<peer>& pp = entry.second;
+        if (!is_regular_member(pp)) continue;
+
+        uint64_t matched_idx = pp->get_matched_idx();
+
+        // Waiting for a member only helps if the leader can still reach it.
+        // The leader does not wait for a member when:
+        //   - its last request failed. The response timer alone does not show
+        //     this, as it is only reset by an accepted response, so a member
+        //     that has just stopped still looks alive until the expiry passes.
+        //   - it did not answer within the expiry time.
+        //   - it has not answered at all yet on a new connection.
+        //
+        // A member receiving a snapshot is waited for. The transfer is no
+        // faster for waiting, but the log stops growing, so the member does
+        // not have to catch up on everything written during the transfer and
+        // then need another snapshot.
+        bool can_be_reached = !pp->get_rpc_errs() &&
+                              pp->get_resp_timer_us() / 1000 <= expiry &&
+                              matched_idx;
+
+        p_tr("backpressure: peer %d matched %" PRIu64 ", resp %" PRIu64 " ms, "
+             "expiry %" PRIu64 " ms, rpc errors %d, snapshot %s, "
+             "can be reached %s",
+             pp->get_id(), matched_idx, pp->get_resp_timer_us() / 1000, expiry,
+             pp->get_rpc_errs(),
+             pp->get_snapshot_sync_ctx() ? "YES" : "NO",
+             can_be_reached ? "YES" : "NO");
+
+        if (!can_be_reached) continue;
+
+        if (matched_idx < clamped_commit_index) {
+            clamped_commit_index = matched_idx;
+            slowest_member = pp->get_id();
+        }
+    }
+
+    // The leader waits for as long as an operator leaves the backpressure on,
+    // so writing a message on every batch would flood the log.
+    if (slowest_member >= 0 &&
+        slow_member_backpressure_log_timer_.timeout_and_reset()) {
+        uint64_t last_log_idx = log_store_->next_slot() - 1;
+        p_in("slow member backpressure: waiting for peer %d at log index "
+             "%" PRIu64 ", %" PRIu64 " entries behind the log tail; without it "
+             "the quorum would commit up to %" PRIu64,
+             slowest_member, clamped_commit_index,
+             last_log_idx > clamped_commit_index
+             ? last_log_idx - clamped_commit_index : 0,
+             expected_commit_index);
+    }
+
+    // A member can be behind the commit index, and one receiving a snapshot
+    // always is, so this can return less than the current commit index.
+    // `commit` ignores anything that does not move it forward, so the most
+    // backpressure can do is freeze the commit index where it is.
+    return clamped_commit_index;
 }
 
 void raft_server::notify_log_append_completion(bool ok) {

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -479,9 +479,53 @@ bool raft_server::send_request(ptr<peer>& p,
     return true;
 }
 
+// Warns a peer that the leader can send it neither the log entries it needs
+// nor a snapshot to replace them with.
+//
+// Marking the peer is part of building the warning rather than something the
+// caller has to remember: replication cannot get such a peer anywhere, but it
+// still answers the warning, and an answer is what the idle time measures, so
+// nothing else tells a caller waiting on peers to catch up that this one never
+// will. The mark is cleared in `create_append_entries_req`, so it lasts only
+// until the leader has something to send again.
+ptr<req_msg> raft_server::create_out_of_log_range_req(peer& p,
+                                                      ulong term,
+                                                      ulong last_log_idx,
+                                                      ulong commit_idx,
+                                                      ulong starting_idx) {
+    p.set_out_of_log_range(true);
+
+    ptr<req_msg> req = cs_new<req_msg>
+                       ( term, msg_type::custom_notification_request,
+                         id_, p.get_id(), 0, last_log_idx, commit_idx );
+
+    // Out-of-log message.
+    ptr<out_of_log_msg> ool_msg = cs_new<out_of_log_msg>();
+    ool_msg->start_idx_of_leader_ = starting_idx;
+
+    // Create a notification containing OOL message.
+    ptr<custom_notification_msg> custom_noti =
+        cs_new<custom_notification_msg>
+        ( custom_notification_msg::out_of_log_range_warning );
+    custom_noti->ctx_ = ool_msg->serialize();
+
+    // Wrap it using log_entry.
+    ptr<log_entry> custom_noti_le =
+        cs_new<log_entry>(0, custom_noti->serialize(), log_val_type::custom);
+
+    req->log_entries().push_back(custom_noti_le);
+    return req;
+}
+
 ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
                                                     ulong custom_last_log_idx) {
     peer& p = *pp;
+
+    // Recomputed below: the only branch that cannot serve this peer marks it
+    // again. Clearing here rather than on each way out keeps the mark from
+    // outliving the decision that set it, whatever paths this function grows.
+    p.set_out_of_log_range(false);
+
     ulong cur_nxt_idx(0L);
     ulong commit_idx(0L);
     ulong last_log_idx(0L);
@@ -680,28 +724,9 @@ ptr<req_msg> raft_server::create_append_entries_req(ptr<peer>& pp ,
              "leader's start log %" PRIu64,
              p.get_id(), last_log_idx, starting_idx);
 
-        // Send out-of-log-range notification to this follower.
-        ptr<req_msg> req = cs_new<req_msg>
-                           ( term, msg_type::custom_notification_request,
-                             id_, p.get_id(), 0, last_log_idx, commit_idx );
-
-        // Out-of-log message.
-        ptr<out_of_log_msg> ool_msg = cs_new<out_of_log_msg>();
-        ool_msg->start_idx_of_leader_ = starting_idx;
-
-        // Create a notification containing OOL message.
-        ptr<custom_notification_msg> custom_noti =
-            cs_new<custom_notification_msg>
-            ( custom_notification_msg::out_of_log_range_warning );
-        custom_noti->ctx_ = ool_msg->serialize();
-
-        // Wrap it using log_entry.
-        ptr<log_entry> custom_noti_le =
-            cs_new<log_entry>(0, custom_noti->serialize(), log_val_type::custom);
-
-        req->log_entries().push_back(custom_noti_le);
         p.reset_cnt_backward_log_probe();
-        return req;
+        return create_out_of_log_range_req( p, term, last_log_idx,
+                                            commit_idx, starting_idx );
     }
 
     ulong last_log_term = term_for_log(last_log_idx);
@@ -1958,6 +1983,10 @@ uint64_t raft_server::apply_slow_member_backpressure(uint64_t expected_commit_in
         //   - the leader does not know where it stands: it has not answered
         //     at all yet on a new connection, and no snapshot is on its way
         //     to it either.
+        //   - it is out of the leader's log range, so the leader has nothing
+        //     left to send it. Such a member answers the warning it is sent,
+        //     which keeps the idle time low, but no amount of waiting
+        //     recovers it.
         //
         // The response timer is reset only by an accepted response, and an
         // accepted response means the member took log entries or saved a
@@ -1971,15 +2000,16 @@ uint64_t raft_server::apply_slow_member_backpressure(uint64_t expected_commit_in
         bool making_progress = !no_progress_timeout ||
                                idle_ms <= (uint64_t)no_progress_timeout;
         bool position_is_known = matched_idx || receiving_snapshot;
-        bool can_be_reached =
-            !pp->get_rpc_errs() && making_progress && position_is_known;
+        bool can_be_reached = !pp->get_rpc_errs() && making_progress &&
+                              position_is_known && !pp->is_out_of_log_range();
 
         p_tr("backpressure: peer %d matched %" PRIu64 ", idle %" PRIu64 " ms, "
              "no progress timeout %d ms, rpc errors %d, snapshot %s, "
-             "can be reached %s",
+             "out of log range %s, can be reached %s",
              pp->get_id(), matched_idx, idle_ms, no_progress_timeout,
              pp->get_rpc_errs(),
              receiving_snapshot ? "YES" : "NO",
+             pp->is_out_of_log_range() ? "YES" : "NO",
              can_be_reached ? "YES" : "NO");
 
         if (!can_be_reached) continue;

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -1937,11 +1937,16 @@ uint64_t raft_server::apply_slow_member_backpressure(uint64_t expected_commit_in
     int32 no_progress_timeout = params->slow_member_backpressure_no_progress_timeout_;
     uint64_t clamped_commit_index = expected_commit_index;
     int32 slowest_member = -1;
+    bool slowest_is_receiving_snapshot = false;
 
     for (auto& entry: peers_) {
         ptr<peer>& pp = entry.second;
         if (!is_regular_member(pp)) continue;
 
+        // Read the snapshot context before `matched_idx`, so that an install
+        // finishing in between is seen as the position it produced rather
+        // than as the reset value it replaced.
+        bool receiving_snapshot = pp->get_snapshot_sync_ctx() != nullptr;
         uint64_t matched_idx = pp->get_matched_idx();
 
         // Waiting for a member only helps if waiting can still get it
@@ -1950,7 +1955,9 @@ uint64_t raft_server::apply_slow_member_backpressure(uint64_t expected_commit_in
         //     idle time below does not show this on its own: a member that
         //     has just stopped still looks busy until the timeout passes.
         //   - it made no progress within the no progress timeout.
-        //   - it has not answered at all yet on a new connection.
+        //   - the leader does not know where it stands: it has not answered
+        //     at all yet on a new connection, and no snapshot is on its way
+        //     to it either.
         //
         // The response timer is reset only by an accepted response, and an
         // accepted response means the member took log entries or saved a
@@ -1963,21 +1970,34 @@ uint64_t raft_server::apply_slow_member_backpressure(uint64_t expected_commit_in
         uint64_t idle_ms = pp->get_resp_timer_us() / 1000;
         bool making_progress = !no_progress_timeout ||
                                idle_ms <= (uint64_t)no_progress_timeout;
-        bool can_be_reached = !pp->get_rpc_errs() && making_progress && matched_idx;
+        bool position_is_known = matched_idx || receiving_snapshot;
+        bool can_be_reached =
+            !pp->get_rpc_errs() && making_progress && position_is_known;
 
         p_tr("backpressure: peer %d matched %" PRIu64 ", idle %" PRIu64 " ms, "
              "no progress timeout %d ms, rpc errors %d, snapshot %s, "
              "can be reached %s",
              pp->get_id(), matched_idx, idle_ms, no_progress_timeout,
              pp->get_rpc_errs(),
-             pp->get_snapshot_sync_ctx() ? "YES" : "NO",
+             receiving_snapshot ? "YES" : "NO",
              can_be_reached ? "YES" : "NO");
 
         if (!can_be_reached) continue;
 
-        if (matched_idx < clamped_commit_index) {
-            clamped_commit_index = matched_idx;
+        // `matched_idx` is reset to zero when the connection to a member is
+        // remade, and written again only once an install completes, so a
+        // member that reconnected and now receives a snapshot reports no
+        // position for the whole transfer. Zero is not a position, it means
+        // the member holds nothing of the log yet, so hold where the leader
+        // already is: that is as far as waiting for it can go.
+        uint64_t member_bound = (receiving_snapshot && !matched_idx)
+                                ? quick_commit_index_.load()
+                                : matched_idx;
+
+        if (member_bound < clamped_commit_index) {
+            clamped_commit_index = member_bound;
             slowest_member = pp->get_id();
+            slowest_is_receiving_snapshot = receiving_snapshot && !matched_idx;
         }
     }
 
@@ -1986,13 +2006,24 @@ uint64_t raft_server::apply_slow_member_backpressure(uint64_t expected_commit_in
     if (slowest_member >= 0 &&
         slow_member_backpressure_log_timer_.timeout_and_reset()) {
         uint64_t last_log_idx = log_store_->next_slot() - 1;
-        p_in("slow member backpressure: waiting for peer %d at log index "
-             "%" PRIu64 ", %" PRIu64 " entries behind the log tail; without it "
-             "the quorum would commit up to %" PRIu64,
-             slowest_member, clamped_commit_index,
-             last_log_idx > clamped_commit_index
-             ? last_log_idx - clamped_commit_index : 0,
-             expected_commit_index);
+        uint64_t behind = last_log_idx > clamped_commit_index
+                          ? last_log_idx - clamped_commit_index : 0;
+        if (slowest_is_receiving_snapshot) {
+            // The member reports no log index at all until the install
+            // finishes, so there is nothing to name but where it is held.
+            p_in("slow member backpressure: waiting for peer %d to receive a "
+                 "snapshot, holding the commit index at %" PRIu64 ", "
+                 "%" PRIu64 " entries behind the log tail; without it the "
+                 "quorum would commit up to %" PRIu64,
+                 slowest_member, clamped_commit_index, behind,
+                 expected_commit_index);
+        } else {
+            p_in("slow member backpressure: waiting for peer %d at log index "
+                 "%" PRIu64 ", %" PRIu64 " entries behind the log tail; without it "
+                 "the quorum would commit up to %" PRIu64,
+                 slowest_member, clamped_commit_index, behind,
+                 expected_commit_index);
+        }
     }
 
     // A member can be behind the commit index, and one receiving a snapshot

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -1932,11 +1932,9 @@ uint64_t raft_server::apply_slow_member_backpressure(uint64_t expected_commit_in
         return expected_commit_index;
     }
 
-    // How long a member may stay silent and still count as reachable, reusing
-    // the limit the leader already applies to the same peers for the same
-    // question in `create_append_entries_req`.
-    uint64_t expiry = (uint64_t)params->heart_beat_interval_ *
-                      raft_server::raft_limits_.full_consensus_leader_limit_;
+    // How long a member may make no progress at all and still be waited for.
+    // `0` means the leader waits for as long as it can reach the member.
+    int32 no_progress_timeout = params->slow_member_backpressure_no_progress_timeout_;
     uint64_t clamped_commit_index = expected_commit_index;
     int32 slowest_member = -1;
 
@@ -1946,26 +1944,31 @@ uint64_t raft_server::apply_slow_member_backpressure(uint64_t expected_commit_in
 
         uint64_t matched_idx = pp->get_matched_idx();
 
-        // Waiting for a member only helps if the leader can still reach it.
-        // The leader does not wait for a member when:
-        //   - its last request failed. The response timer alone does not show
-        //     this, as it is only reset by an accepted response, so a member
-        //     that has just stopped still looks alive until the expiry passes.
-        //   - it did not answer within the expiry time.
+        // Waiting for a member only helps if waiting can still get it
+        // anywhere. The leader stops waiting for a member when:
+        //   - its last request failed, so it cannot be reached at all. The
+        //     idle time below does not show this on its own: a member that
+        //     has just stopped still looks busy until the timeout passes.
+        //   - it made no progress within the no progress timeout.
         //   - it has not answered at all yet on a new connection.
         //
-        // A member receiving a snapshot is waited for. The transfer is no
-        // faster for waiting, but the log stops growing, so the member does
-        // not have to catch up on everything written during the transfer and
-        // then need another snapshot.
-        bool can_be_reached = !pp->get_rpc_errs() &&
-                              pp->get_resp_timer_us() / 1000 <= expiry &&
-                              matched_idx;
+        // The response timer is reset only by an accepted response, and an
+        // accepted response means the member took log entries or saved a
+        // snapshot object, so the idle time measures progress rather than
+        // reachability. That is why a member receiving a snapshot is waited
+        // for: it keeps making progress, one object at a time. The transfer
+        // is no faster for waiting, but the log stops growing, so the member
+        // does not have to catch up on everything written during it and then
+        // need another snapshot.
+        uint64_t idle_ms = pp->get_resp_timer_us() / 1000;
+        bool making_progress = !no_progress_timeout ||
+                               idle_ms <= (uint64_t)no_progress_timeout;
+        bool can_be_reached = !pp->get_rpc_errs() && making_progress && matched_idx;
 
-        p_tr("backpressure: peer %d matched %" PRIu64 ", resp %" PRIu64 " ms, "
-             "expiry %" PRIu64 " ms, rpc errors %d, snapshot %s, "
+        p_tr("backpressure: peer %d matched %" PRIu64 ", idle %" PRIu64 " ms, "
+             "no progress timeout %d ms, rpc errors %d, snapshot %s, "
              "can be reached %s",
-             pp->get_id(), matched_idx, pp->get_resp_timer_us() / 1000, expiry,
+             pp->get_id(), matched_idx, idle_ms, no_progress_timeout,
              pp->get_rpc_errs(),
              pp->get_snapshot_sync_ctx() ? "YES" : "NO",
              can_be_reached ? "YES" : "NO");

--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -159,7 +159,7 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req,
     uint64_t request_entries = 0;
     uint64_t max_entries = 0;
     if (should_reject_client_request_by_uncommitted_log_entries(entries,
-                                                                params->max_uncommitted_log_entries_,
+                                                                get_max_uncommitted_log_entries(),
                                                                 current_entries,
                                                                 request_entries,
                                                                 max_entries)) {

--- a/src/handle_custom_notification.cxx
+++ b/src/handle_custom_notification.cxx
@@ -136,6 +136,33 @@ ptr<buffer> force_vote_msg::serialize() const {
 }
 
 
+// --- slow_member_backpressure_msg ---
+
+ptr<slow_member_backpressure_msg> slow_member_backpressure_msg::deserialize(buffer& buf) {
+    ptr<slow_member_backpressure_msg> ret = cs_new<slow_member_backpressure_msg>();
+    buffer_serializer bs(buf);
+    uint8_t version = bs.get_u8();
+    (void)version;
+    ret->enable_ = bs.get_u8() != 0;
+    return ret;
+}
+
+ptr<buffer> slow_member_backpressure_msg::serialize() const {
+    //   << Format >>
+    // version                      1 byte
+    // enable flag                  1 byte
+
+    size_t len = sizeof(uint8_t) + sizeof(uint8_t);
+    ptr<buffer> ret = buffer::alloc(len);
+
+    const uint8_t CURRENT_VERSION = 0x0;
+    buffer_serializer bs(ret);
+    bs.put_u8(CURRENT_VERSION);
+    bs.put_u8(enable_ ? 1 : 0);
+    return ret;
+}
+
+
 // --- handlers ---
 
 ptr<resp_msg> raft_server::handle_custom_notification_req(req_msg& req) {
@@ -170,6 +197,9 @@ ptr<resp_msg> raft_server::handle_custom_notification_req(req_msg& req) {
     }
     case custom_notification_msg::request_leadership: {
         return handle_request_leadership_request(req, msg, resp);
+    }
+    case custom_notification_msg::set_slow_member_backpressure: {
+        return handle_slow_member_backpressure_request(req, msg, resp);
     }
     default:
         break;
@@ -261,6 +291,71 @@ ptr<resp_msg> raft_server::handle_request_leadership_request
     return resp;
 }
 
+ptr<resp_msg> raft_server::handle_slow_member_backpressure_request
+                           ( req_msg& req,
+                             ptr<custom_notification_msg> msg,
+                             ptr<resp_msg> resp )
+{
+    if (!msg->ctx_) {
+        p_er("[SLOW MEMBER BACKPRESSURE] got request from peer %d "
+             "without context", req.get_src());
+        return resp;
+    }
+
+    if (req.get_term() < state_->get_term()) {
+        // An old term means that the sender does not know it is no longer the
+        // leader. Ignoring the message also stops two servers that both think
+        // they are the leader from sending the setting back and forth.
+        p_wn("[SLOW MEMBER BACKPRESSURE] got request from peer %d with stale "
+             "term %" PRIu64 ", my term %" PRIu64 ", ignore it",
+             req.get_src(), req.get_term(), state_->get_term());
+        return resp;
+    }
+
+    // A newer term proves that this node is behind, and that it is not the
+    // leader any more, even if it still thinks so. Step down first: a server
+    // that is no longer the leader must not send the setting on with its old
+    // term.
+    update_term(req.get_term());
+
+    ptr<slow_member_backpressure_msg> bp_msg =
+        slow_member_backpressure_msg::deserialize(*msg->ctx_);
+
+    if (is_leader()) {
+        // A follower asks this leader to change the setting. Apply it here
+        // and send it on: only the leader uses the setting, but every node
+        // should report the same value.
+        p_in("[SLOW MEMBER BACKPRESSURE] got request from peer %d to turn it %s",
+             req.get_src(), bp_msg->enable_ ? "ON" : "OFF");
+        switch_slow_member_backpressure(bp_msg->enable_);
+        broadcast_slow_member_backpressure(bp_msg->enable_);
+
+    } else if (req.get_src() == leader_ || leader_ == -1) {
+        // The current leader sends the setting. Apply it here.
+        //
+        // NOTE: `leader_ == -1` is accepted as well. Without that, a message
+        //       that arrives at the same time as a leader change would always
+        //       be dropped. During that short time this node cannot check that
+        //       the sender is the leader. It can only check that the sender is
+        //       in the current term. That is enough here, because the setting
+        //       changes availability and not safety.
+        p_in("[SLOW MEMBER BACKPRESSURE] leader %d turned it %s",
+             req.get_src(), bp_msg->enable_ ? "ON" : "OFF");
+        switch_slow_member_backpressure(bp_msg->enable_);
+
+    } else {
+        // A server that has just lost leadership still has its old `leader_`,
+        // so a message from the new leader is dropped here. That is not
+        // repaired later: a new leader switches the setting off rather than
+        // publishing it, so an operator turns it on again if it is wanted.
+        p_wn("[SLOW MEMBER BACKPRESSURE] got request from peer %d, but this "
+             "node is not a leader and the request is not from the current "
+             "leader %d", req.get_src(), leader_.load());
+    }
+
+    return resp;
+}
+
 
 void raft_server::handle_custom_notification_resp(resp_msg& resp) {
     if (!resp.get_accepted()) return;
@@ -272,7 +367,18 @@ void raft_server::handle_custom_notification_resp(resp_msg& resp) {
     }
     ptr<peer> p = it->second;
 
-    p->set_next_log_idx(resp.get_next_idx());
+    // NOTE: Only move the next log index forward. A custom notification does
+    //       not replicate log entries, but its response still carries the
+    //       peer's `next_slot`. While the peer is catching up or receiving a
+    //       snapshot, that value is lower than what the leader has already
+    //       sent. Moving the index back would make the leader send the same
+    //       entries again, or decide that the peer needs a snapshot once more
+    //       and start the transfer from the beginning. The probe counter is
+    //       reset in both cases, as it always was: the response proves that
+    //       the peer can be reached.
+    if (resp.get_next_idx() > p->get_next_log_idx()) {
+        p->set_next_log_idx(resp.get_next_idx());
+    }
     p->reset_cnt_backward_log_probe();
 }
 

--- a/src/handle_custom_notification.cxx
+++ b/src/handle_custom_notification.cxx
@@ -322,35 +322,19 @@ ptr<resp_msg> raft_server::handle_slow_member_backpressure_request
         slow_member_backpressure_msg::deserialize(*msg->ctx_);
 
     if (is_leader()) {
-        // A follower asks this leader to change the setting. Apply it here
-        // and send it on: only the leader uses the setting, but every node
-        // should report the same value.
+        // A follower asks this leader to change the setting. Only the leader
+        // holds it, so applying it here is all there is to do.
         p_in("[SLOW MEMBER BACKPRESSURE] got request from peer %d to turn it %s",
-             req.get_src(), bp_msg->enable_ ? "ON" : "OFF");
-        switch_slow_member_backpressure(bp_msg->enable_);
-        broadcast_slow_member_backpressure(bp_msg->enable_);
-
-    } else if (req.get_src() == leader_ || leader_ == -1) {
-        // The current leader sends the setting. Apply it here.
-        //
-        // NOTE: `leader_ == -1` is accepted as well. Without that, a message
-        //       that arrives at the same time as a leader change would always
-        //       be dropped. During that short time this node cannot check that
-        //       the sender is the leader. It can only check that the sender is
-        //       in the current term. That is enough here, because the setting
-        //       changes availability and not safety.
-        p_in("[SLOW MEMBER BACKPRESSURE] leader %d turned it %s",
              req.get_src(), bp_msg->enable_ ? "ON" : "OFF");
         switch_slow_member_backpressure(bp_msg->enable_);
 
     } else {
-        // A server that has just lost leadership still has its old `leader_`,
-        // so a message from the new leader is dropped here. That is not
-        // repaired later: a new leader switches the setting off rather than
-        // publishing it, so an operator turns it on again if it is wanted.
+        // Only a leader is ever sent this request, so getting one here means
+        // the sender's view of the leader is out of date. Dropping it is
+        // right: this server would not act on the setting anyway, and it must
+        // not start reporting one it cannot apply.
         p_wn("[SLOW MEMBER BACKPRESSURE] got request from peer %d, but this "
-             "node is not a leader and the request is not from the current "
-             "leader %d", req.get_src(), leader_.load());
+             "server is not the leader", req.get_src());
     }
 
     return resp;

--- a/src/handle_custom_notification.cxx
+++ b/src/handle_custom_notification.cxx
@@ -303,19 +303,19 @@ ptr<resp_msg> raft_server::handle_slow_member_backpressure_request
     }
 
     if (req.get_term() < state_->get_term()) {
-        // An old term means that the sender does not know it is no longer the
-        // leader. Ignoring the message also stops two servers that both think
-        // they are the leader from sending the setting back and forth.
+        // An old term means the sender is behind, so its view of who leads
+        // is not to be trusted either. Only the leader applies the setting,
+        // and a stale request is no reason to change it.
         p_wn("[SLOW MEMBER BACKPRESSURE] got request from peer %d with stale "
              "term %" PRIu64 ", my term %" PRIu64 ", ignore it",
              req.get_src(), req.get_term(), state_->get_term());
         return resp;
     }
 
-    // A newer term proves that this node is behind, and that it is not the
-    // leader any more, even if it still thinks so. Step down first: a server
-    // that is no longer the leader must not send the setting on with its old
-    // term.
+    // A newer term proves that this server is behind, and that it is not the
+    // leader any more even if it still thinks so. Step down before looking at
+    // the request, so that a deposed leader does not apply a setting only a
+    // leader may hold.
     update_term(req.get_term());
 
     ptr<slow_member_backpressure_msg> bp_msg =

--- a/src/handle_custom_notification.hxx
+++ b/src/handle_custom_notification.hxx
@@ -31,6 +31,7 @@ public:
         leadership_takeover         = 2,
         request_resignation         = 3,
         request_leadership          = 4,
+        set_slow_member_backpressure = 5,
     };
 
     custom_notification_msg(type t = out_of_log_range_warning)
@@ -67,6 +68,19 @@ public:
     static ptr<force_vote_msg> deserialize(buffer& buf);
 
     ptr<buffer> serialize() const;
+};
+
+class slow_member_backpressure_msg {
+public:
+    slow_member_backpressure_msg(bool enable = false)
+        : enable_(enable)
+        {}
+
+    static ptr<slow_member_backpressure_msg> deserialize(buffer& buf);
+
+    ptr<buffer> serialize() const;
+
+    bool enable_;
 };
 
 } // namespace nuraft;

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1256,13 +1256,12 @@ void raft_server::become_leader() {
         config_changing_ = true;
     }
 
-    // The slow member backpressure lasts for one leadership. Only the leader
-    // acts on the setting, and this server may have missed the message that
-    // switched it, so its own copy is not to be trusted: acting on a stale
-    // `true` would throttle the cluster again after an operator had switched
-    // it off, with nothing to show why. Switching it off here makes the loss
-    // of backpressure at a leader change certain instead of accidental, and an
-    // operator turns it on again if it is still wanted.
+    // The slow member backpressure lasts for one leadership, so a server that
+    // has just been elected must not start throttling on the strength of a
+    // setting from an earlier one. `become_follower` clears it as well, so
+    // reaching here with it still on means this server went from leader to
+    // candidate and back without ever stepping down; clearing it again costs
+    // nothing and keeps the rule simple to state.
     if (ctx_->get_params()->slow_member_backpressure_enabled_) {
         p_in("slow member backpressure was on: switching it off, as it does "
              "not carry over to a new leader");

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -422,6 +422,7 @@ void raft_server::apply_and_log_current_params() {
           "parallel log appending: %s, "
           "streaming mode max log gap %d, max bytes %" PRIu64 ", "
           "full consensus mode: %s, "
+          "slow member backpressure: %s, "
           "tracking peer sm committed index: %s, "
           "max uncommitted log entries %" PRIu64,
           params->election_timeout_lower_bound_,
@@ -449,6 +450,7 @@ void raft_server::apply_and_log_current_params() {
           params->max_log_gap_in_stream_,
           params->max_bytes_in_flight_in_stream_,
           params->use_full_consensus_among_healthy_members_ ? "ON" : "OFF",
+          params->slow_member_backpressure_enabled_ ? "ON" : "OFF",
           params->track_peers_sm_commit_idx_ ? "ON" : "OFF",
           params->max_uncommitted_log_entries_
         );
@@ -458,6 +460,26 @@ void raft_server::apply_and_log_current_params() {
 
     leadership_transfer_timer_.set_duration_ms
         (params->leadership_transfer_min_wait_time_);
+}
+
+uint64_t raft_server::get_max_uncommitted_log_entries() const {
+    ptr<raft_params> params = ctx_->get_params();
+    uint64_t configured = params->max_uncommitted_log_entries_;
+    if (!params->slow_member_backpressure_enabled_) {
+        return configured;
+    }
+
+    uint64_t while_backpressure_on =
+        params->slow_member_backpressure_max_uncommitted_;
+    if (!while_backpressure_on) {
+        return configured;
+    }
+    if (!configured) {
+        // `0` means no limit at all, so it must not win over the limit that
+        // backpressure asks for.
+        return while_backpressure_on;
+    }
+    return std::min(configured, while_backpressure_on);
 }
 
 raft_params raft_server::get_current_params() const {
@@ -1234,6 +1256,19 @@ void raft_server::become_leader() {
         config_changing_ = true;
     }
 
+    // The slow member backpressure lasts for one leadership. Only the leader
+    // acts on the setting, and this server may have missed the message that
+    // switched it, so its own copy is not to be trusted: acting on a stale
+    // `true` would throttle the cluster again after an operator had switched
+    // it off, with nothing to show why. Switching it off here makes the loss
+    // of backpressure at a leader change certain instead of accidental, and an
+    // operator turns it on again if it is still wanted.
+    if (ctx_->get_params()->slow_member_backpressure_enabled_) {
+        p_in("slow member backpressure was on: switching it off, as it does "
+             "not carry over to a new leader");
+        switch_slow_member_backpressure(false);
+    }
+
     cb_func::Param param(id_, leader_);
     ulong my_term = state_->get_term();
     param.ctx = &my_term;
@@ -1579,6 +1614,106 @@ bool raft_server::request_leadership(int successor_id) {
             return false;
         }
     }
+}
+
+void raft_server::switch_slow_member_backpressure(bool enable) {
+    recur_lock(lock_);
+    if (ctx_->get_params()->slow_member_backpressure_enabled_ == enable) {
+        p_in("slow member backpressure is already %s", enable ? "ON" : "OFF");
+        return;
+    }
+    raft_params params = *ctx_->get_params();
+    params.slow_member_backpressure_enabled_ = enable;
+    update_params(params);
+}
+
+ptr<req_msg> raft_server::create_slow_member_backpressure_req(int dst,
+                                                              bool enable) {
+    ptr<req_msg> req = cs_new<req_msg>
+                       ( state_->get_term(),
+                         msg_type::custom_notification_request,
+                         id_, dst,
+                         term_for_log(log_store_->next_slot() - 1),
+                         log_store_->next_slot() - 1,
+                         quick_commit_index_.load() );
+
+    ptr<custom_notification_msg> custom_noti =
+        cs_new<custom_notification_msg>
+        ( custom_notification_msg::set_slow_member_backpressure );
+    custom_noti->ctx_ =
+        cs_new<slow_member_backpressure_msg>(enable)->serialize();
+
+    req->log_entries().push_back(
+        cs_new<log_entry>(0, custom_noti->serialize(), log_val_type::custom) );
+
+    return req;
+}
+
+void raft_server::broadcast_slow_member_backpressure(bool enable) {
+    recur_lock(lock_);
+    for (auto& entry: peers_) {
+        ptr<peer> pp = entry.second;
+
+        ptr<req_msg> req =
+            create_slow_member_backpressure_req(pp->get_id(), enable);
+
+        if (pp->make_busy()) {
+            pp->send_req(pp, req, resp_handler_);
+        } else {
+            // Best-effort: the peer keeps its old setting. That only changes
+            // what the peer reports, not what the leader does, until the peer
+            // becomes the leader itself and sends its old setting on.
+            p_wn("cannot propagate slow member backpressure to peer %d, "
+                 "peer is busy", pp->get_id());
+        }
+    }
+}
+
+bool raft_server::request_slow_member_backpressure(bool enable) {
+    if (is_leader()) {
+        p_in("turning slow member backpressure %s", enable ? "ON" : "OFF");
+        switch_slow_member_backpressure(enable);
+        broadcast_slow_member_backpressure(enable);
+        return true;
+    }
+
+    if (leader_ == -1) {
+        p_er("cannot request slow member backpressure: cannot find leader");
+        return false;
+    }
+
+    ptr<req_msg> req = create_slow_member_backpressure_req(leader_, enable);
+
+    recur_lock(lock_);
+    auto entry = peers_.find(leader_);
+    if (entry == peers_.end()) {
+        p_er("cannot request slow member backpressure: cannot find peer for "
+             "leader id %d", leader_.load());
+        return false;
+    }
+
+    ptr<peer> pp = entry->second;
+    if (pp->need_to_reconnect()) {
+        p_in("need to reconnect to peer %d", leader_.load());
+        ptr<srv_config> s_conf = get_config()->get_server(leader_);
+        if (!s_conf) {
+            p_wn("can't reconnect to peer %d: config not found", leader_.load());
+            return false;
+        }
+        if (!pp->recreate_rpc(s_conf, *ctx_)) {
+            p_wn("reconnection to peer %d failed", leader_.load());
+            return false;
+        }
+    }
+
+    if (pp->make_busy()) {
+        p_in("requesting slow member backpressure %s from leader %d",
+             enable ? "ON" : "OFF", leader_.load());
+        pp->send_req(pp, req, resp_handler_);
+        return true;
+    }
+    p_in("cannot request slow member backpressure, leader is busy");
+    return false;
 }
 
 void raft_server::become_follower() {

--- a/src/raft_server.cxx
+++ b/src/raft_server.cxx
@@ -1649,31 +1649,10 @@ ptr<req_msg> raft_server::create_slow_member_backpressure_req(int dst,
     return req;
 }
 
-void raft_server::broadcast_slow_member_backpressure(bool enable) {
-    recur_lock(lock_);
-    for (auto& entry: peers_) {
-        ptr<peer> pp = entry.second;
-
-        ptr<req_msg> req =
-            create_slow_member_backpressure_req(pp->get_id(), enable);
-
-        if (pp->make_busy()) {
-            pp->send_req(pp, req, resp_handler_);
-        } else {
-            // Best-effort: the peer keeps its old setting. That only changes
-            // what the peer reports, not what the leader does, until the peer
-            // becomes the leader itself and sends its old setting on.
-            p_wn("cannot propagate slow member backpressure to peer %d, "
-                 "peer is busy", pp->get_id());
-        }
-    }
-}
-
 bool raft_server::request_slow_member_backpressure(bool enable) {
     if (is_leader()) {
         p_in("turning slow member backpressure %s", enable ? "ON" : "OFF");
         switch_slow_member_backpressure(enable);
-        broadcast_slow_member_backpressure(enable);
         return true;
     }
 
@@ -1720,6 +1699,17 @@ void raft_server::become_follower() {
     // stop hb for all peers
     p_in("[BECOME FOLLOWER] term %" PRIu64 "", state_->get_term());
     ptr<raft_params> params = ctx_->get_params();
+
+    // Only a leader acts on the slow member backpressure, so a server that is
+    // no longer the leader must not keep reporting it as on. Together with the
+    // same reset in `become_leader`, this keeps the setting true only on a
+    // leader an operator asked, so every server reports its own copy truthfully.
+    if (params->slow_member_backpressure_enabled_) {
+        p_in("slow member backpressure was on: switching it off, as this "
+             "server is no longer the leader");
+        switch_slow_member_backpressure(false);
+        params = ctx_->get_params();
+    }
     {   std::lock_guard<std::recursive_mutex> ll(cli_lock_);
         if (params->use_bg_thread_for_snapshot_io_) {
             snapshot_io_mgr::instance().drop_reqs(this);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,14 @@ unit_test(NAME raft_server_test
     ${EXAMPLES_SRC}/in_memory_log_store.cxx
 )
 
+unit_test(NAME slow_member_backpressure_test
+    SOURCES
+    unit/slow_member_backpressure_test.cxx
+    unit/fake_network.cxx
+    ${EXAMPLES_SRC}/logger.cc
+    ${EXAMPLES_SRC}/in_memory_log_store.cxx
+)
+
 unit_test(NAME snapshot_test
     SOURCES
     unit/snapshot_test.cxx

--- a/tests/unit/fake_network.hxx
+++ b/tests/unit/fake_network.hxx
@@ -176,6 +176,15 @@ public:
         }
     }
 
+    int32 getPeerRpcErrs(raft_server* srv, int32 peer_id) {
+        auto& peers = get_peers(srv);
+        auto it = peers.find(peer_id);
+        if (it != peers.end()) {
+            return it->second->get_rpc_errs();
+        }
+        return 0;
+    }
+
     ulong getPeerMatchedIdx(raft_server* srv, int32 peer_id) {
         auto& peers = get_peers(srv);
         auto it = peers.find(peer_id);

--- a/tests/unit/slow_member_backpressure_test.cxx
+++ b/tests/unit/slow_member_backpressure_test.cxx
@@ -636,10 +636,61 @@ int refuses_new_requests_while_active_test() {
     return 0;
 }
 
+// The switch lasts for one leadership, and a server that stops leading must
+// stop reporting it. Only a leader acts on the setting, so a deposed leader
+// that kept a stale `true` would tell an operator the cluster is throttled
+// when it is not - and `mntr` is read exactly when that matters.
+int switched_off_when_leadership_is_lost_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers(pkgs) );
+    CHK_Z( make_group(pkgs) );
+
+    CHK_TRUE( s1.raftServer->is_leader() );
+    CHK_TRUE( s1.raftServer->request_slow_member_backpressure(true) );
+    CHK_TRUE( s1.raftServer->get_current_params()
+                  .slow_member_backpressure_enabled_ );
+
+    // Hand leadership to S3, the same way `leader_election_test` does.
+    s2.fTimer->invoke( timer_task_type::election_timer );
+    s2.fNet->execReqResp();
+    s3.fTimer->invoke( timer_task_type::election_timer );
+    // Pre-vote, then vote.
+    s3.fNet->execReqResp();
+    s3.fNet->execReqResp();
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    s3.fNet->execReqResp();
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+
+    CHK_FALSE( s1.raftServer->is_leader() );
+    CHK_TRUE( s3.raftServer->is_leader() );
+
+    // The old leader must have let go of it, and the new one must not have
+    // picked it up.
+    CHK_FALSE( s1.raftServer->get_current_params()
+                   .slow_member_backpressure_enabled_ );
+    CHK_FALSE( s3.raftServer->get_current_params()
+                   .slow_member_backpressure_enabled_ );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
 // The switch itself: off by default, a follower's request reaches the leader,
-// the leader uses it and sends it on, and turning it off releases the member.
-// Nothing else in this file covers the switch, so without this test the whole
-// switch could be removed and every other test would still pass.
+// only the leader holds it, and turning it off releases the member. Nothing
+// else in this file covers the switch, so without this test the whole switch
+// could be removed and every other test would still pass.
 int runtime_toggle_test() {
     reset_log_files();
     ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
@@ -680,11 +731,12 @@ int runtime_toggle_test() {
     CHK_TRUE( s1.raftServer->get_current_params()
                   .slow_member_backpressure_enabled_ );
 
-    // The leader sends it on, so the other members report it too.
-    s1.fNet->execReqResp(s2_addr);
-    s1.fNet->execReqResp(s3_addr);
-    CHK_TRUE( s2.raftServer->get_current_params()
-                  .slow_member_backpressure_enabled_ );
+    // Only the leader holds it. A follower that asked for it does not set it
+    // locally, so every server reports a value it can actually act on.
+    CHK_FALSE( s2.raftServer->get_current_params()
+                   .slow_member_backpressure_enabled_ );
+    CHK_FALSE( s3.raftServer->get_current_params()
+                   .slow_member_backpressure_enabled_ );
 
     // On: the same lag now holds the commit index back.
     append_and_deliver_to(s1, LAG * 2, {s2_addr}, "on");
@@ -697,11 +749,10 @@ int runtime_toggle_test() {
     CHK_FALSE( s1.raftServer->get_current_params()
                    .slow_member_backpressure_enabled_ );
     append_and_deliver_to(s1, 1, {s2_addr}, "off_again");
-    // Turning it off also sends the setting to every peer, over the same
-    // connection as the append answers, so keep delivering S2's messages until
-    // the commit index reaches the last log entry. S3 is left far behind on
-    // purpose: if the commit index were still held, delivering S2's messages
-    // could never move it past S3's matched index.
+    // Keep delivering S2's messages until the commit index reaches the last
+    // log entry. S3 is left far behind on purpose: if the commit index were
+    // still held, delivering S2's messages could never move it past S3's
+    // matched index.
     uint64_t last_log_idx = tail(s1);
     for (int ii = 0; ii < 40; ++ii) {
         if (s1.raftServer->get_target_committed_log_idx() == last_log_idx) break;
@@ -758,6 +809,9 @@ int main(int argc, char** argv) {
 
     ts.doTest( "runtime toggle test",
                runtime_toggle_test );
+
+    ts.doTest( "switched off when leadership is lost test",
+               switched_off_when_leadership_is_lost_test );
 
     return 0;
 }

--- a/tests/unit/slow_member_backpressure_test.cxx
+++ b/tests/unit/slow_member_backpressure_test.cxx
@@ -226,8 +226,8 @@ int not_held_with_custom_quorum_size_test() {
 // A member whose requests fail cannot catch up by being waited for, so the
 // leader must stop waiting as soon as a request to it fails. The rpc error is
 // the only signal available at that moment: the response timer is only reset
-// by an accepted response, so a member that has just stopped still looks
-// responsive until the expiry passes.
+// by an accepted response, so a member that has just stopped still looks busy
+// until the no progress timeout passes.
 int rpc_error_alone_releases_lagging_member_test() {
     reset_log_files();
     ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();

--- a/tests/unit/slow_member_backpressure_test.cxx
+++ b/tests/unit/slow_member_backpressure_test.cxx
@@ -330,9 +330,10 @@ int never_responded_member_is_not_held_test() {
 }
 
 // A member that goes silent without its requests failing must be released too:
-// it cannot catch up while it is not answering, so waiting for it only stalls
-// the cluster. This is the responsiveness window on its own, with no rpc error
-// and a matched index already known, which is what every other test conflates.
+// it makes no progress while it is not answering, so waiting for it only
+// stalls the cluster. This is the no progress timeout on its own, with no rpc
+// error and a matched index already known, which is what every other test
+// conflates.
 int silent_member_is_released_test() {
     reset_log_files();
     ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
@@ -346,26 +347,13 @@ int silent_member_is_released_test() {
     RaftPkg s3(f_base, 3, s3_addr);
     std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
 
-    // Shrink the responsiveness window so silence is noticed within the test:
-    // it is `full_consensus_leader_limit` heartbeats. These limits are process
-    // global, so put them back however this test ends - an early return from a
-    // failed check would otherwise leave the shrunken window in place for
-    // every test that runs afterwards.
-    struct limits_guard {
-        explicit limits_guard(raft_server::limits saved): saved_(saved) {}
-        ~limits_guard() { raft_server::set_raft_limits(saved_); }
-        raft_server::limits saved_;
-    } guard(raft_server::get_raft_limits());
-
-    raft_server::limits new_limits = raft_server::get_raft_limits();
-    new_limits.full_consensus_leader_limit_ = 2;
-    raft_server::set_raft_limits(new_limits);
-
     CHK_Z( prepare(pkgs) );
     for (RaftPkg* pkg: pkgs) {
         raft_params params = pkg->raftServer->get_current_params();
-        params.heart_beat_interval_ = 20;
-        params.max_append_size_ = 1;
+        // Short enough to pass within the test. The default is measured in
+        // tens of seconds, because a member applying a big snapshot is quiet
+        // for a long time and is exactly the one worth waiting for.
+        params.slow_member_backpressure_no_progress_timeout_ = 100;
         pkg->raftServer->update_params(params);
     }
 
@@ -376,12 +364,51 @@ int silent_member_is_released_test() {
     CHK_GT( matched_idx_of(s1, 3), (uint64_t)0 );
     CHK_HELD( s1 );
 
-    // Now it simply stops answering. Once the window passes it is no longer
-    // eligible, so the commit index proceeds on the majority.
-    TestSuite::sleep_ms(20 * 2 * 5, "let the responsiveness window pass");
+    // Now it simply stops making progress. Once the timeout passes it is no
+    // longer waited for, so the commit index proceeds on the majority.
+    TestSuite::sleep_ms(300, "let the no progress timeout pass");
     append_and_deliver_to(s1, 1, {s2_addr}, "silent_more");
     while (s1.fNet->execReqResp(s2_addr)) {}
     CHK_NOT_HELD( s1 );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+// With the no progress timeout switched off, a member that the leader can
+// still reach is waited for however long it takes. An operator who asks for
+// that has to be able to rely on it: nothing but `bpof` should end it.
+int no_progress_timeout_zero_waits_indefinitely_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( prepare(pkgs) );
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        params.slow_member_backpressure_no_progress_timeout_ = 0;
+        pkg->raftServer->update_params(params);
+    }
+
+    append_and_deliver_to(s1, LAG * 2, {s2_addr}, "forever");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    CHK_HELD( s1 );
+
+    // Long enough that any timeout short enough to be useful would have
+    // expired. S3 answers nothing, and its requests do not fail.
+    TestSuite::sleep_ms(300, "stay silent");
+    append_and_deliver_to(s1, 1, {s2_addr}, "still_forever");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    CHK_HELD( s1 );
 
     for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
     f_base->destroy();
@@ -797,6 +824,9 @@ int main(int argc, char** argv) {
 
     ts.doTest( "silent member is released test",
                silent_member_is_released_test );
+
+    ts.doTest( "no progress timeout zero waits indefinitely test",
+               no_progress_timeout_zero_waits_indefinitely_test );
 
     ts.doTest( "snapshot receiver is held test",
                snapshot_receiver_is_held_test );

--- a/tests/unit/slow_member_backpressure_test.cxx
+++ b/tests/unit/slow_member_backpressure_test.cxx
@@ -1,0 +1,763 @@
+/************************************************************************
+Copyright 2017-2019 eBay Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**************************************************************************/
+
+#include "debugging_options.hxx"
+#include "fake_network.hxx"
+#include "raft_package_fake.hxx"
+
+#include "event_awaiter.hxx"
+#include "raft_params.hxx"
+#include "test_common.h"
+
+#include <stdio.h>
+#include <string>
+
+using namespace nuraft;
+using namespace raft_functional_common;
+
+namespace slow_member_backpressure_test {
+
+// How far a member is left behind in these tests. The backpressure has no
+// threshold of its own, so this is only an amount of entries that is easy to
+// see in the assertions.
+static const size_t LAG = 5;
+
+// Appends `num` messages on the leader, and delivers the resulting messages to
+// `endpoints` only, so that any peer left out keeps its matched index while its
+// connection stays healthy: alive, but failing to keep up.
+static void append_and_deliver_to(RaftPkg& leader,
+                                  size_t num,
+                                  const std::vector<std::string>& endpoints,
+                                  const std::string& prefix,
+                                  const std::vector<std::string>& failing = {})
+{
+    for (size_t ii = 0; ii < num; ++ii) {
+        std::string test_msg = prefix + std::to_string(ii);
+        ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+        msg->put(test_msg);
+        leader.raftServer->append_entries( {msg} );
+
+        for (const std::string& endpoint: endpoints) {
+            // Request, then response.
+            leader.fNet->execReqResp(endpoint);
+            leader.fNet->execReqResp(endpoint);
+        }
+        for (const std::string& endpoint: failing) {
+            // Deliver the request as a failure, so that the leader observes
+            // the peer as unreachable rather than merely silent.
+            leader.fNet->makeReqFailAll(endpoint);
+        }
+    }
+}
+
+// The last log index of the leader's own log, i.e. how far ahead of a member
+// the leader has run.
+static uint64_t tail(RaftPkg& leader) {
+    return leader.getTestMgr()->load_log_store()->next_slot() - 1;
+}
+
+// Whether the commit index is being held short of the log.
+//
+// Always the commit index and never the state machine index: the feature
+// clamps the former, and the latter trails it on the apply thread, so
+// asserting on it can pass while a member is wrongly held, or fail while it
+// is not.
+#define CHK_HELD(pkg) \
+    CHK_GT( tail(pkg), (pkg).raftServer->get_target_committed_log_idx() )
+#define CHK_NOT_HELD(pkg) \
+    CHK_EQ( tail(pkg), (pkg).raftServer->get_target_committed_log_idx() )
+
+// The last log index of a peer, from the leader's point of view. This is
+// `last_accepted_log_idx_`, which the leader sets together with the matched
+// index the backpressure reads, and which is the only one exposed publicly.
+static uint64_t matched_idx_of(RaftPkg& leader, int32_t peer_id) {
+    return leader.raftServer->get_peer_info(peer_id).last_log_idx_;
+}
+
+// Turns the backpressure on directly in the parameters. The switch that an
+// operator uses is covered by `runtime_toggle_test`.
+static int prepare(std::vector<RaftPkg*>& pkgs) {
+    CHK_Z( launch_servers(pkgs) );
+    CHK_Z( make_group(pkgs) );
+
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        // Otherwise `append_entries` blocks until commit, which is exactly
+        // what this test holds back on purpose.
+        params.return_method_ = raft_params::async_handler;
+        // Off by default: an operator turns it on, so the tests do too.
+        params.slow_member_backpressure_enabled_ = true;
+        // These tests build a backlog by appending while the commit index is
+        // held, so the append brake has to stay out of the way.
+        // `refuses_new_requests_while_active_test` sets its own value,
+        // because the brake is what it tests.
+        params.slow_member_backpressure_max_uncommitted_ = 0;
+        pkg->raftServer->update_params(params);
+    }
+    return 0;
+}
+
+// A member that is alive but falling behind must hold the commit index back,
+// even though the other members form a majority. There is no threshold: the
+// commit index follows the slowest member entry by entry.
+int holds_commit_for_lagging_member_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( prepare(pkgs) );
+
+    // A single entry that S3 does not get is already enough: S1 and S2 are a
+    // majority, and the commit index still does not move past S3.
+    uint64_t behind_at = matched_idx_of(s1, 3);
+    append_and_deliver_to(s1, 1, {s2_addr}, "one");
+    CHK_HELD( s1 );
+    CHK_EQ( behind_at, s1.raftServer->get_target_committed_log_idx() );
+
+    // The leader runs further ahead, and the commit index stays exactly at
+    // S3's matched index rather than at the majority's.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr}, "held");
+    uint64_t last_log_idx = tail(s1);
+    CHK_EQ( behind_at, matched_idx_of(s1, 3) );
+    CHK_EQ( behind_at, s1.raftServer->get_target_committed_log_idx() );
+    CHK_GT( last_log_idx, behind_at );
+
+    // Let S3 catch up. Once it has everything, commits resume.
+    for (size_t ii = 0; ii < LAG * 6; ++ii) {
+        s1.fNet->execReqResp(s3_addr);
+    }
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_EQ( last_log_idx, s1.raftServer->get_committed_log_idx() );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+// A learner is not part of the quorum, so the leader must never wait for it.
+int learner_is_never_held_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    auto init_cb = [&](RaftPkg* pp) {
+        if (pp->myId == 3) {
+            pp->getTestMgr()->get_srv_config()->set_learner(true);
+        }
+    };
+    CHK_Z( launch_servers( pkgs, nullptr, false, cb_default, init_cb ) );
+    CHK_Z( make_group( pkgs ) );
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        params.return_method_ = raft_params::async_handler;
+        params.slow_member_backpressure_enabled_ = true;
+        pkg->raftServer->update_params(params);
+    }
+
+    // The learner falls far behind, and the two voting members commit anyway.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr}, "learner");
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_EQ( tail(s1), s1.raftServer->get_committed_log_idx() );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+// While a custom commit quorum size is in force the quorum is overridden on
+// purpose, so nothing may be held back.
+int not_held_with_custom_quorum_size_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( prepare(pkgs) );
+
+    raft_params params = s1.raftServer->get_current_params();
+    params.custom_commit_quorum_size_ = 2;
+    s1.raftServer->update_params(params);
+
+    append_and_deliver_to(s1, LAG * 2, {s2_addr}, "custom");
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_EQ( tail(s1), s1.raftServer->get_committed_log_idx() );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+// A member whose requests fail cannot catch up by being waited for, so the
+// leader must stop waiting as soon as a request to it fails. The rpc error is
+// the only signal available at that moment: the response timer is only reset
+// by an accepted response, so a member that has just stopped still looks
+// responsive until the expiry passes.
+int rpc_error_alone_releases_lagging_member_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( prepare(pkgs) );
+
+    // S3 falls behind with a healthy connection: the leader waits for it.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr}, "pre");
+    uint64_t matched_before = matched_idx_of(s1, 3);
+    CHK_GT( matched_before, 0 );
+    CHK_HELD( s1 );
+
+    // One more entry. Deliver only the request to S2 and keep its response,
+    // so that the commit evaluation can be triggered at a chosen moment.
+    std::string test_msg = "probe";
+    ptr<buffer> msg = buffer::alloc(test_msg.size() + 1);
+    msg->put(test_msg);
+    s1.raftServer->append_entries( {msg} );
+    s1.fNet->delieverReqTo(s2_addr);
+
+    // Now S3's outstanding request fails. The leader has not sent it anything
+    // since, so its matched index is still intact: only the rpc error can
+    // tell the leader that waiting is pointless.
+    s1.fNet->makeReqFailAll(s3_addr);
+    CHK_EQ( matched_before, matched_idx_of(s1, 3) );
+
+    // S2's response arrives and the leader re-evaluates the commit index.
+    // S3 is unreachable, so it must not be waited for anymore.
+    s1.fNet->handleRespFrom(s2_addr);
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_EQ( tail(s1), s1.raftServer->get_committed_log_idx() );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+// A member that has never acknowledged anything (matched index zero) must not
+// be waited for, even though its connection is healthy and has never failed.
+// A failed request would also raise the rpc error counter and exclude the
+// member anyway, hiding a bug in the matched-index check, so this member is
+// freshly added instead: healthy connection, no errors, no acknowledgements.
+int never_responded_member_is_not_held_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+    std::string s4_addr = "S4";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    RaftPkg s4(f_base, 4, s4_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( prepare(pkgs) );
+    std::vector<RaftPkg*> pkgs4 = {&s4};
+    CHK_Z( launch_servers(pkgs4) );
+
+    // Add S4 to the cluster, delivering only what the membership change
+    // itself needs: the join request to S4 and the configuration entry to S2
+    // and S3. S4 becomes a voting member the leader has never heard from.
+    s1.raftServer->add_srv( *(s4.getTestMgr()->get_srv_config()) );
+    // Join req/resp, log sync req/resp.
+    s1.fNet->execReqResp(s4_addr);
+    s1.fNet->execReqResp(s4_addr);
+    // Configuration entry to the existing members.
+    s1.fNet->execReqResp(s2_addr);
+    s1.fNet->execReqResp(s2_addr);
+    s1.fNet->execReqResp(s3_addr);
+    s1.fNet->execReqResp(s3_addr);
+    std::vector<RaftPkg*> pkgs_no_s4 = {&s1, &s2, &s3};
+    CHK_Z( wait_for_sm_exec(pkgs_no_s4, COMMIT_TIMEOUT_SEC) );
+
+    // S4 is a member now, and it has never responded to anything.
+    CHK_EQ( 0, matched_idx_of(s1, 4) );
+
+    // S1, S2 and S3 are a majority of four, and waiting for S4 cannot help:
+    // everything must keep committing.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr, s3_addr}, "fresh");
+    CHK_Z( wait_for_sm_exec(pkgs_no_s4, COMMIT_TIMEOUT_SEC) );
+    CHK_EQ( tail(s1), s1.raftServer->get_committed_log_idx() );
+    CHK_EQ( 0, matched_idx_of(s1, 4) );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    s4.raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+// A member that goes silent without its requests failing must be released too:
+// it cannot catch up while it is not answering, so waiting for it only stalls
+// the cluster. This is the responsiveness window on its own, with no rpc error
+// and a matched index already known, which is what every other test conflates.
+int silent_member_is_released_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    // Shrink the responsiveness window so silence is noticed within the test:
+    // it is `full_consensus_leader_limit` heartbeats. These limits are process
+    // global, so put them back however this test ends - an early return from a
+    // failed check would otherwise leave the shrunken window in place for
+    // every test that runs afterwards.
+    struct limits_guard {
+        explicit limits_guard(raft_server::limits saved): saved_(saved) {}
+        ~limits_guard() { raft_server::set_raft_limits(saved_); }
+        raft_server::limits saved_;
+    } guard(raft_server::get_raft_limits());
+
+    raft_server::limits new_limits = raft_server::get_raft_limits();
+    new_limits.full_consensus_leader_limit_ = 2;
+    raft_server::set_raft_limits(new_limits);
+
+    CHK_Z( prepare(pkgs) );
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        params.heart_beat_interval_ = 20;
+        params.max_append_size_ = 1;
+        pkg->raftServer->update_params(params);
+    }
+
+    // S3 falls behind and is waited for, with its matched index known and no
+    // errors.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr}, "silent");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    CHK_GT( matched_idx_of(s1, 3), (uint64_t)0 );
+    CHK_HELD( s1 );
+
+    // Now it simply stops answering. Once the window passes it is no longer
+    // eligible, so the commit index proceeds on the majority.
+    TestSuite::sleep_ms(20 * 2 * 5, "let the responsiveness window pass");
+    append_and_deliver_to(s1, 1, {s2_addr}, "silent_more");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    CHK_NOT_HELD( s1 );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+// Counts snapshot chunks saved by any receiver, so that
+// `snapshot_receiver_is_held_test` can prove a transfer really started.
+static std::atomic<uint64_t> num_snapshot_chunks_saved(0);
+
+static cb_func::ReturnCode cb_count_snapshot_chunks(cb_func::Type type,
+                                                    cb_func::Param* param)
+{
+    if (type == cb_func::Type::SaveSnapshot) {
+        num_snapshot_chunks_saved.fetch_add(1);
+    }
+    return cb_default(type, param);
+}
+
+// A member receiving a snapshot is waited for as well. The transfer is no
+// faster for waiting, but the log stops growing, so the member does not have
+// to catch up on everything written during the transfer and then need another
+// snapshot.
+//
+// Its matched index is stale and below the commit index, which is the case the
+// floor at the current commit index has to survive: without the floor the
+// leader would hand the state machine a commit index below the one it has
+// already applied.
+int snapshot_receiver_is_held_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    num_snapshot_chunks_saved = 0;
+    CHK_Z( launch_servers(pkgs, nullptr, false, cb_count_snapshot_chunks) );
+    CHK_Z( make_group(pkgs) );
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        params.return_method_ = raft_params::async_handler;
+        // One entry per batch, so that a single exchange with S3 cannot catch
+        // it up and the exchange after it has to be a snapshot: `RaftPkg`
+        // takes a snapshot every 5 commits, and S3 will be behind the latest
+        // one.
+        params.max_append_size_ = 1;
+        // Off to begin with, so that the commit index can run past S3 before
+        // the transfer starts. That is what makes S3's matched index stale.
+        params.slow_member_backpressure_enabled_ = false;
+        pkg->raftServer->update_params(params);
+    }
+
+    // Entries commit everywhere first, so that there is a snapshot for S3 to
+    // fall behind.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr, s3_addr}, "base");
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    for (int ii = 0; ii < 200 && s1.getTestSm()->getNumSnapshotCreations() == 0;
+         ++ii) {
+        // Snapshots are created on the apply thread, so wait for it rather
+        // than assuming it has caught up already.
+        TestSuite::sleep_ms(10, "wait for a snapshot");
+    }
+    CHK_GT( s1.getTestSm()->getNumSnapshotCreations(), 0 );
+
+    // S3 stops receiving and the leader commits without it, so the commit
+    // index ends up well above S3's matched index.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr}, "ahead");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+
+    // The leader finds that S3's next log index is at or below the latest
+    // snapshot and starts sending it. Stop as soon as the first chunk is
+    // saved: the transfer has to be still in progress below.
+    for (int ii = 0; ii < 10 && !num_snapshot_chunks_saved; ++ii) {
+        s1.fNet->execReqResp(s3_addr);
+    }
+    CHK_GT( num_snapshot_chunks_saved.load(), (uint64_t)0 );
+
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        params.slow_member_backpressure_enabled_ = true;
+        pkg->raftServer->update_params(params);
+    }
+
+    uint64_t frozen_at = s1.raftServer->get_target_committed_log_idx();
+    CHK_SM( matched_idx_of(s1, 3), frozen_at );
+
+    // Keep writing and committing through S2 while the transfer is in
+    // progress. The commit index must stay exactly where it was: not lower,
+    // which would un-commit applied entries, and not higher, which would mean
+    // the leader is still outrunning the member it is waiting for.
+    for (int ii = 0; ii < 20; ++ii) {
+        append_and_deliver_to(s1, 1, {s2_addr}, "during" + std::to_string(ii));
+        while (s1.fNet->execReqResp(s2_addr)) {}
+        CHK_EQ( frozen_at, s1.raftServer->get_target_committed_log_idx() );
+    }
+    CHK_HELD( s1 );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+// With more than one member behind, the commit index must follow the one that
+// is furthest behind, not the nearest one and not the quorum.
+int holds_at_the_furthest_lagging_member_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+    std::string s4_addr = "S4";
+    std::string s5_addr = "S5";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    RaftPkg s4(f_base, 4, s4_addr);
+    RaftPkg s5(f_base, 5, s5_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3, &s4, &s5};
+
+    CHK_Z( prepare(pkgs) );
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        params.max_append_size_ = 1;
+        // No snapshots: a member far enough behind would be sent one, which
+        // excludes it for a reason unrelated to what this test checks.
+        params.snapshot_distance_ = 0;
+        pkg->raftServer->update_params(params);
+    }
+
+    // S4 and S5 stop receiving, so both fall behind.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr, s3_addr}, "two_a");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    while (s1.fNet->execReqResp(s3_addr)) {}
+    CHK_HELD( s1 );
+    uint64_t frozen_at = s1.raftServer->get_target_committed_log_idx();
+
+    // The tail runs far ahead while they stay behind.
+    append_and_deliver_to(s1, LAG * 8, {s2_addr, s3_addr}, "two_b");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    while (s1.fNet->execReqResp(s3_addr)) {}
+
+    // Both catch up past the point where the commit index froze, but to
+    // different positions and both still far from the tail. They are advanced
+    // by different amounts on purpose, so that holding at either one of them
+    // gives a different commit index and the choice is observable.
+    for (int ii = 0; ii < 200 && matched_idx_of(s1, 5) < frozen_at + 3; ++ii) {
+        s1.fNet->execReqResp(s5_addr);
+    }
+    for (int ii = 0; ii < 400 && matched_idx_of(s1, 4) < frozen_at + 12; ++ii) {
+        s1.fNet->execReqResp(s4_addr);
+    }
+    uint64_t furthest = matched_idx_of(s1, 5);
+    CHK_GT( furthest, frozen_at );
+    CHK_SM( furthest, matched_idx_of(s1, 4) );
+    CHK_GT( tail(s1) - matched_idx_of(s1, 4), LAG );
+
+    // Held at the member that is furthest behind, so the commit index reaches
+    // its position and no further - not the position of the nearer one.
+    append_and_deliver_to(s1, 1, {s2_addr, s3_addr}, "two_c");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    while (s1.fNet->execReqResp(s3_addr)) {}
+    CHK_EQ( furthest, s1.raftServer->get_target_committed_log_idx() );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+// Holding the commit index does not by itself stop the leader from taking new
+// writes, so the leader must also refuse them once too many entries are
+// uncommitted. Otherwise the log keeps growing and the member falls even
+// further behind.
+int refuses_new_requests_while_active_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( prepare(pkgs) );
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        // No general limit, so that only the backpressure one can refuse.
+        params.max_uncommitted_log_entries_ = 0;
+        params.slow_member_backpressure_max_uncommitted_ = LAG;
+        pkg->raftServer->update_params(params);
+    }
+
+    auto append = [&](const std::string& text) {
+        ptr<buffer> msg = buffer::alloc(text.size() + 1);
+        msg->put(text);
+        return s1.raftServer->append_entries( {msg} );
+    };
+
+    // Everything commits, so nothing is uncommitted and nothing is refused.
+    // In async mode an accepted request has no result yet; only a rejection
+    // sets a result code straight away.
+    for (size_t ii = 0; ii < LAG * 2; ++ii) {
+        CHK_EQ( cmd_result_code::RESULT_NOT_EXIST_YET,
+                append("ok" + std::to_string(ii))->get_result_code() );
+        for (const std::string& endpoint: {s2_addr, s3_addr}) {
+            s1.fNet->execReqResp(endpoint);
+            s1.fNet->execReqResp(endpoint);
+        }
+    }
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+
+    // S3 stops receiving. The commit index stops with it, so uncommitted
+    // entries pile up until the leader refuses, within one entry of the limit.
+    uint64_t refused_after = 0;
+    for (size_t ii = 0; ii < LAG * 3; ++ii) {
+        uint64_t last_log_idx = tail(s1);
+        if (append("pile" + std::to_string(ii))->get_result_code() ==
+            cmd_result_code::TIMEOUT) {
+            // A refused request must not reach the log.
+            CHK_EQ( last_log_idx, tail(s1) );
+            refused_after = ii;
+            break;
+        }
+        s1.fNet->execReqResp(s2_addr);
+        s1.fNet->execReqResp(s2_addr);
+    }
+    CHK_GT( refused_after, (uint64_t)0 );
+    CHK_SMEQ( refused_after, (uint64_t)(LAG + 1) );
+    CHK_HELD( s1 );
+
+    // Once S3 catches up everything commits, and requests are accepted again.
+    for (size_t ii = 0; ii < LAG * 8; ++ii) {
+        s1.fNet->execReqResp(s3_addr);
+    }
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_EQ( cmd_result_code::RESULT_NOT_EXIST_YET,
+            append("accepted")->get_result_code() );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+// The switch itself: off by default, a follower's request reaches the leader,
+// the leader uses it and sends it on, and turning it off releases the member.
+// Nothing else in this file covers the switch, so without this test the whole
+// switch could be removed and every other test would still pass.
+int runtime_toggle_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers(pkgs) );
+    CHK_Z( make_group(pkgs) );
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        params.return_method_ = raft_params::async_handler;
+        // No snapshots: a member that falls behind far enough would be sent
+        // one, which excludes it for a reason that has nothing to do with the
+        // switch under test.
+        params.snapshot_distance_ = 0;
+        pkg->raftServer->update_params(params);
+        // Not enabled on purpose: that is the default state an operator
+        // starts from.
+        CHK_FALSE( pkg->raftServer->get_current_params()
+                       .slow_member_backpressure_enabled_ );
+    }
+
+    // Off: the leader just runs ahead of a member that falls behind.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr}, "off");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    CHK_NOT_HELD( s1 );
+
+    // A follower asks for it, which has to reach the leader.
+    CHK_TRUE( s3.raftServer->request_slow_member_backpressure(true) );
+    s3.fNet->execReqResp(s1_addr);
+    CHK_TRUE( s1.raftServer->get_current_params()
+                  .slow_member_backpressure_enabled_ );
+
+    // The leader sends it on, so the other members report it too.
+    s1.fNet->execReqResp(s2_addr);
+    s1.fNet->execReqResp(s3_addr);
+    CHK_TRUE( s2.raftServer->get_current_params()
+                  .slow_member_backpressure_enabled_ );
+
+    // On: the same lag now holds the commit index back.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr}, "on");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    CHK_HELD( s1 );
+
+    // Off again, from the leader this time: the commit index is released
+    // without the member having caught up.
+    CHK_TRUE( s1.raftServer->request_slow_member_backpressure(false) );
+    CHK_FALSE( s1.raftServer->get_current_params()
+                   .slow_member_backpressure_enabled_ );
+    append_and_deliver_to(s1, 1, {s2_addr}, "off_again");
+    // Turning it off also sends the setting to every peer, over the same
+    // connection as the append answers, so keep delivering S2's messages until
+    // the commit index reaches the last log entry. S3 is left far behind on
+    // purpose: if the commit index were still held, delivering S2's messages
+    // could never move it past S3's matched index.
+    uint64_t last_log_idx = tail(s1);
+    for (int ii = 0; ii < 40; ++ii) {
+        if (s1.raftServer->get_target_committed_log_idx() == last_log_idx) break;
+        // The heartbeat is what re-sends an entry to a peer that was busy with
+        // the switch message when it was appended.
+        s1.fTimer->invoke( timer_task_type::heartbeat_timer );
+        while (s1.fNet->execReqResp(s2_addr)) {}
+    }
+    CHK_EQ( last_log_idx, s1.raftServer->get_target_committed_log_idx() );
+    CHK_GT( last_log_idx - matched_idx_of(s1, 3), LAG );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
+}  // namespace slow_member_backpressure_test
+using namespace slow_member_backpressure_test;
+
+int main(int argc, char** argv) {
+    TestSuite ts(argc, argv);
+
+    ts.options.printTestMessage = true;
+
+    // Deterministic behavior.
+    debugging_options::get_instance().disable_reconn_backoff_ = true;
+
+    ts.doTest( "holds commit for lagging member test",
+               holds_commit_for_lagging_member_test );
+
+    ts.doTest( "learner is never held test",
+               learner_is_never_held_test );
+
+    ts.doTest( "not held with custom quorum size test",
+               not_held_with_custom_quorum_size_test );
+
+    ts.doTest( "rpc error alone releases lagging member test",
+               rpc_error_alone_releases_lagging_member_test );
+
+    ts.doTest( "never responded member is not held test",
+               never_responded_member_is_not_held_test );
+
+    ts.doTest( "silent member is released test",
+               silent_member_is_released_test );
+
+    ts.doTest( "snapshot receiver is held test",
+               snapshot_receiver_is_held_test );
+
+    ts.doTest( "holds at the furthest lagging member test",
+               holds_at_the_furthest_lagging_member_test );
+
+    ts.doTest( "refuses new requests while active test",
+               refuses_new_requests_while_active_test );
+
+    ts.doTest( "runtime toggle test",
+               runtime_toggle_test );
+
+    return 0;
+}

--- a/tests/unit/slow_member_backpressure_test.cxx
+++ b/tests/unit/slow_member_backpressure_test.cxx
@@ -518,6 +518,110 @@ int snapshot_receiver_is_held_test() {
     return 0;
 }
 
+// The same as `snapshot_receiver_is_held_test`, except that the member loses
+// its connection before the transfer begins, which is how a restarted member
+// comes back. Reconnecting resets its matched index to zero, and the index is
+// written again only once the install completes, so for the whole transfer the
+// member reports no position at all.
+//
+// Zero must not be read as "nothing to wait for" here. It means that when the
+// leader has no idea where a member stands, so waiting for it could freeze the
+// commit index for nothing; but a member being sent a snapshot is not unknown,
+// the leader knows precisely that it holds nothing of the log yet. Leaving it
+// out is what lets the leader outrun a snapshot receiver and make it need
+// another snapshot as soon as the first one lands.
+int reconnected_snapshot_receiver_is_held_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    num_snapshot_chunks_saved = 0;
+    CHK_Z( launch_servers(pkgs, nullptr, false, cb_count_snapshot_chunks) );
+    CHK_Z( make_group(pkgs) );
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        params.return_method_ = raft_params::async_handler;
+        // One entry per batch, so that a single exchange with S3 cannot catch
+        // it up and the exchange after it has to be a snapshot.
+        params.max_append_size_ = 1;
+        // Off to begin with, so that the commit index can run past S3 before
+        // the transfer starts.
+        params.slow_member_backpressure_enabled_ = false;
+        pkg->raftServer->update_params(params);
+    }
+
+    // Entries commit everywhere first, so that there is a snapshot for S3 to
+    // fall behind.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr, s3_addr}, "base");
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    for (int ii = 0; ii < 200 && s1.getTestSm()->getNumSnapshotCreations() == 0;
+         ++ii) {
+        TestSuite::sleep_ms(10, "wait for a snapshot");
+    }
+    CHK_GT( s1.getTestSm()->getNumSnapshotCreations(), 0 );
+
+    // S3 stops receiving and the leader commits without it.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr}, "ahead");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_GT( matched_idx_of(s1, 3), (uint64_t)0 );
+
+    // S3 goes away and comes back: its requests fail, and the leader loses the
+    // connection. The next request to it is sent over a new one, and that is
+    // what resets the matched index.
+    s1.fNet->makeReqFailAll(s3_addr);
+    s1.dropPeerConnection(3);
+    append_and_deliver_to(s1, 1, {s2_addr}, "reconnect");
+    CHK_EQ( (ulong)0, s1.fNet->getPeerMatchedIdx(s1.raftServer.get(), 3) );
+
+    // The leader probes S3 backwards, runs out of log to send it, and starts a
+    // snapshot. Stop as soon as the first chunk is saved: the transfer has to
+    // be still in progress below.
+    for (int ii = 0; ii < 40 && !num_snapshot_chunks_saved; ++ii) {
+        s1.fNet->execReqResp(s3_addr);
+    }
+    CHK_GT( num_snapshot_chunks_saved.load(), (uint64_t)0 );
+    CHK_TRUE( s1.fNet->hasPeerSnapshotSyncCtx(s1.raftServer.get(), 3) );
+
+    // The whole point of the case: a transfer is in flight and the member
+    // still reports nothing. The other two exclusion reasons must not be
+    // standing in for the one under test, or this would pass without the
+    // member being waited for at all.
+    CHK_EQ( (ulong)0, s1.fNet->getPeerMatchedIdx(s1.raftServer.get(), 3) );
+    CHK_Z( s1.fNet->getPeerRpcErrs(s1.raftServer.get(), 3) );
+
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        params.slow_member_backpressure_enabled_ = true;
+        pkg->raftServer->update_params(params);
+    }
+
+    uint64_t frozen_at = s1.raftServer->get_target_committed_log_idx();
+
+    // Keep writing and committing through S2 while the transfer is in
+    // progress. The commit index must stay exactly where it was: not lower,
+    // which would un-commit applied entries, and not higher, which would mean
+    // the leader is outrunning the member it is supposed to be waiting for.
+    for (int ii = 0; ii < 20; ++ii) {
+        append_and_deliver_to(s1, 1, {s2_addr}, "during" + std::to_string(ii));
+        while (s1.fNet->execReqResp(s2_addr)) {}
+        CHK_EQ( frozen_at, s1.raftServer->get_target_committed_log_idx() );
+    }
+    CHK_HELD( s1 );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
 // With more than one member behind, the commit index must follow the one that
 // is furthest behind, not the nearest one and not the quorum.
 int holds_at_the_furthest_lagging_member_test() {
@@ -830,6 +934,9 @@ int main(int argc, char** argv) {
 
     ts.doTest( "snapshot receiver is held test",
                snapshot_receiver_is_held_test );
+
+    ts.doTest( "reconnected snapshot receiver is held test",
+               reconnected_snapshot_receiver_is_held_test );
 
     ts.doTest( "holds at the furthest lagging member test",
                holds_at_the_furthest_lagging_member_test );

--- a/tests/unit/slow_member_backpressure_test.cxx
+++ b/tests/unit/slow_member_backpressure_test.cxx
@@ -622,6 +622,93 @@ int reconnected_snapshot_receiver_is_held_test() {
     return 0;
 }
 
+// A member that is out of the leader's log range must be left out. The
+// entries it needs are gone and no snapshot covers it, so replication cannot
+// recover it however long the leader waits.
+//
+// Nothing else in the exclusion list catches it. It answers the warning the
+// leader sends, and an accepted answer is what resets the idle time, so it
+// keeps looking like it is making progress; its matched index is whatever it
+// reached before falling out of range, so it looks known; and its requests do
+// not fail, so it looks reachable. Waiting for it would pin the commit index
+// until an operator noticed and switched the backpressure off by hand.
+int out_of_log_range_member_is_not_held_test() {
+    reset_log_files();
+    ptr<FakeNetworkBase> f_base = cs_new<FakeNetworkBase>();
+
+    std::string s1_addr = "S1";
+    std::string s2_addr = "S2";
+    std::string s3_addr = "S3";
+
+    RaftPkg s1(f_base, 1, s1_addr);
+    RaftPkg s2(f_base, 2, s2_addr);
+    RaftPkg s3(f_base, 3, s3_addr);
+    std::vector<RaftPkg*> pkgs = {&s1, &s2, &s3};
+
+    CHK_Z( launch_servers(pkgs) );
+    CHK_Z( make_group(pkgs) );
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        params.return_method_ = raft_params::async_handler;
+        // Off to begin with: the log has to compact past S3 before the
+        // backpressure could hold anything.
+        params.slow_member_backpressure_enabled_ = false;
+        pkg->raftServer->update_params(params);
+    }
+
+    // Commit everywhere first, so that S3 has a position to fall behind from
+    // and the leader takes a snapshot and compacts its log.
+    append_and_deliver_to(s1, LAG * 2, {s2_addr, s3_addr}, "base");
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_GT( matched_idx_of(s1, 3), (uint64_t)0 );
+
+    // S3 stops receiving, and the leader commits and compacts without it.
+    append_and_deliver_to(s1, LAG * 4, {s2_addr}, "ahead");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    for (int ii = 0; ii < 200 && s1.getTestSm()->getNumSnapshotCreations() == 0;
+         ++ii) {
+        // Snapshots are created on the apply thread, so wait for it rather
+        // than assuming it has caught up already.
+        TestSuite::sleep_ms(10, "wait for a snapshot");
+    }
+    CHK_GT( s1.getTestSm()->getNumSnapshotCreations(), 0 );
+
+    // Take the snapshot away, so that the leader has neither the entries S3
+    // needs nor a snapshot to replace them with.
+    s1.fNet->clearLastSnapshot(s1.raftServer.get());
+
+    for (RaftPkg* pkg: pkgs) {
+        raft_params params = pkg->raftServer->get_current_params();
+        params.slow_member_backpressure_enabled_ = true;
+        pkg->raftServer->update_params(params);
+    }
+
+    // The leader finds it can send S3 nothing and warns it instead.
+    for (int ii = 0; ii < 20 &&
+                     !s3.fNet->isServerOutOfLogRange(s3.raftServer.get()); ++ii) {
+        s1.fNet->execReqResp(s3_addr);
+    }
+    CHK_TRUE( s3.fNet->isServerOutOfLogRange(s3.raftServer.get()) );
+
+    // None of the other reasons to leave a member out applies here, so this
+    // test cannot pass on one of them by accident.
+    CHK_GT( s1.fNet->getPeerMatchedIdx(s1.raftServer.get(), 3), (ulong)0 );
+    CHK_Z( s1.fNet->getPeerRpcErrs(s1.raftServer.get(), 3) );
+    CHK_FALSE( s1.fNet->hasPeerSnapshotSyncCtx(s1.raftServer.get(), 3) );
+
+    // S1 and S2 are a majority, and waiting for S3 cannot get it anywhere:
+    // everything must keep committing.
+    append_and_deliver_to(s1, LAG, {s2_addr}, "after");
+    while (s1.fNet->execReqResp(s2_addr)) {}
+    CHK_Z( wait_for_sm_exec(pkgs, COMMIT_TIMEOUT_SEC) );
+    CHK_NOT_HELD( s1 );
+
+    for (RaftPkg* pkg: pkgs) pkg->raftServer->shutdown();
+    f_base->destroy();
+    return 0;
+}
+
 // With more than one member behind, the commit index must follow the one that
 // is furthest behind, not the nearest one and not the quorum.
 int holds_at_the_furthest_lagging_member_test() {
@@ -937,6 +1024,9 @@ int main(int argc, char** argv) {
 
     ts.doTest( "reconnected snapshot receiver is held test",
                reconnected_snapshot_receiver_is_held_test );
+
+    ts.doTest( "out of log range member is not held test",
+               out_of_log_range_member_is_not_held_test );
 
     ts.doTest( "holds at the furthest lagging member test",
                holds_at_the_furthest_lagging_member_test );


### PR DESCRIPTION
Added slow member backpressure: while it is on, the leader does not commit past any member it is still waiting for, so that a member which has fallen behind can catch up. A member is waited for however far behind it is, including while it receives a snapshot, and is left out only when waiting cannot get it anywhere: the leader cannot reach it, or it made no progress within `slow_member_backpressure_no_progress_timeout_`, which defaults to 30 s and counts an accepted response as progress. The behaviour is switched with `request_slow_member_backpressure` while the server runs and lasts for one leadership until disabled, only the leader holds it, and `slow_member_backpressure_max_uncommitted_` makes the leader refuse new writes while it is on. 