### PR TITLE
Add log_entry::user_data and state_machine::ext_op_params::log_entry

### DIFF
--- a/include/libnuraft/log_entry.hxx
+++ b/include/libnuraft/log_entry.hxx
@@ -130,6 +130,13 @@ public:
         return term;
     }
 
+    /**
+     * Arbitrary user data that the application can attach to the in-memory log entry,
+     * e.g. a cached deserialization of the payload. Not serialized, not replicated,
+     * ignored by NuRaft.
+     */
+    ptr<void> user_data;
+
 private:
     /**
      * The term number when this log entry was generated.

--- a/include/libnuraft/state_machine.hxx
+++ b/include/libnuraft/state_machine.hxx
@@ -33,6 +33,8 @@ namespace nuraft {
 
 class cluster_config;
 class snapshot;
+class log_entry;
+
 class state_machine {
     __interface_body__(state_machine);
 
@@ -40,14 +42,17 @@ public:
     struct ext_op_params {
         ext_op_params(ulong _log_idx,
                       ptr<buffer>& _data,
+                      const ptr<log_entry>& _log_entry,
                       ulong _log_term = 0)
             : log_idx(_log_idx)
             , log_term(_log_term)
             , data(_data)
+            , log_entry(_log_entry)
             {}
         ulong log_idx;
         ulong log_term;
         ptr<buffer>& data;
+        const ptr<log_entry>& log_entry;
         // May add more parameters in the future.
     };
 

--- a/include/libnuraft/state_machine.hxx
+++ b/include/libnuraft/state_machine.hxx
@@ -47,12 +47,12 @@ public:
             : log_idx(_log_idx)
             , log_term(_log_term)
             , data(_data)
-            , log_entry(_log_entry)
+            , entry(_log_entry)
             {}
         ulong log_idx;
         ulong log_term;
         ptr<buffer>& data;
-        const ptr<log_entry>& log_entry;
+        const ptr<log_entry>& entry;
         // May add more parameters in the future.
     };
 

--- a/src/client_req_stream.cxx
+++ b/src/client_req_stream.cxx
@@ -45,7 +45,8 @@ void client_req_stream::append(std::vector< ptr<buffer> > logs)
 
     state_->in_flight_.fetch_add(1);
 
-    auto handle_result = [state = state_](bool success)
+    ptr<State> state = state_;
+    auto handle_result = [state](bool success)
     {
         if (!success) state->abandoned_.store(true);
         size_t prev_in_flight = state->in_flight_.fetch_sub(1);
@@ -67,7 +68,7 @@ void client_req_stream::append(std::vector< ptr<buffer> > logs)
         if (resp && resp->has_async_cb()) {
             ptr< cmd_result< ptr<buffer> > > ret = resp->call_async_cb();
             ret->when_ready(
-                [handle_result = std::move(handle_result)]
+                [handle_result]
                 ( cmd_result<ptr<buffer>, ptr<std::exception>>& res,
                     ptr<std::exception>& exp ) {
                     bool success = !exp && res.get_accepted() &&
@@ -89,7 +90,7 @@ void client_req_stream::append(std::vector< ptr<buffer> > logs)
     }
 
     rpc_handler handler =
-        [handle_result = std::move(handle_result)]
+        [handle_result]
         (ptr<resp_msg>& resp, ptr<rpc_exception>& err) {
             bool success = !err && resp && resp->get_accepted() &&
                 resp->get_result_code() == cmd_result_code::OK;

--- a/src/handle_append_entries.cxx
+++ b/src/handle_append_entries.cxx
@@ -1094,7 +1094,7 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
                 if (old_entry->get_val_type() == log_val_type::app_log) {
                     buf->pos(0);
                     state_machine_->rollback_ext
-                        ( state_machine::ext_op_params( idx, buf ) );
+                        ( state_machine::ext_op_params( idx, buf, old_entry ) );
                     p_in( "rollback log %" PRIu64 ", term %" PRIu64,
                           idx, old_entry->get_term() );
 
@@ -1128,7 +1128,7 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
                 ptr<buffer> buf = entry->get_buf_ptr();
                 buf->pos(0);
                 state_machine_->pre_commit_ext
-                    ( state_machine::ext_op_params( log_idx, buf ) );
+                    ( state_machine::ext_op_params( log_idx, buf, entry ) );
 
             } else if(entry->get_val_type() == log_val_type::conf) {
                 p_in("receive a config change from leader at %" PRIu64, log_idx);
@@ -1167,7 +1167,7 @@ ptr<resp_msg> raft_server::handle_append_entries(req_msg& req)
                 ptr<buffer> buf = entry->get_buf_ptr();
                 buf->pos(0);
                 state_machine_->pre_commit_ext
-                    ( state_machine::ext_op_params( idx_for_entry, buf ) );
+                    ( state_machine::ext_op_params( idx_for_entry, buf, entry ) );
             }
 
             if (stopping_) return resp;

--- a/src/handle_client_request.cxx
+++ b/src/handle_client_request.cxx
@@ -210,7 +210,7 @@ ptr<resp_msg> raft_server::handle_cli_req(req_msg& req,
         ptr<buffer> buf = entry->get_buf_ptr();
         buf->pos(0);
         ret_value = state_machine_->pre_commit_ext
-                    ( state_machine::ext_op_params( last_idx, buf ) );
+                    ( state_machine::ext_op_params( last_idx, buf, entry ) );
 
         if (ext_params.after_precommit_) {
             req_ext_cb_params cb_params;

--- a/src/handle_commit.cxx
+++ b/src/handle_commit.cxx
@@ -395,7 +395,7 @@ void raft_server::commit_app_log(ulong idx_to_commit,
         _sys_exit(-1);
     }
     ret_value = state_machine_->commit_ext
-                ( state_machine::ext_op_params( sm_idx, buf, le->get_term() ) );
+                ( state_machine::ext_op_params( sm_idx, buf, le, le->get_term() ) );
     if (ret_value) ret_value->pos(0);
 
     auto params = ctx_->get_params();


### PR DESCRIPTION
To be used for pass deserialized keeper log entries around, replacing the silly `KeeperStateMachine::parsed_request_cache` thing.