### PR TITLE
Fix four `asio_service` bugs found in one Keeper CI run

### DIFF
--- a/include/libnuraft/asio_service_options.hxx
+++ b/include/libnuraft/asio_service_options.hxx
@@ -137,6 +137,7 @@ struct asio_service_options {
         , corrupted_msg_handler_(nullptr)
         , streaming_mode_(false)
         , custom_io_context_(nullptr)
+        , connection_timeout_ms_(10 * 1000)
         {}
 
     /**
@@ -310,6 +311,18 @@ struct asio_service_options {
 #else
     asio::io_context* custom_io_context_;
 #endif
+
+    /**
+     * Timeout of establishing a connection, covering the TCP connection and
+     * the SSL handshake. If the peer accepts the connection but never
+     * finishes the handshake, nothing else bounds the wait, and the request
+     * that triggered the connection is never completed: its callback is not
+     * invoked, so the caller cannot learn about it and cannot retry.
+     *
+     * It does not apply to a request that carries its own timeout in
+     * `rpc_client::send`, and it is disabled if set to zero.
+     */
+    uint64_t connection_timeout_ms_;
 };
 
 }

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1784,10 +1784,19 @@ private:
                 asio::ip::tcp::resolver::results_type endpoints ) -> void
         {
             if (!err) {
-                if (send_timeout_ms != 0) {
+                // This timer covers the connection and the SSL handshake, and
+                // `handle_handshake` cancels it. Without it, a peer that accepts
+                // the connection but never finishes the handshake makes this
+                // request wait forever: `when_done` is never invoked, so the
+                // caller keeps the request in flight and never retries.
+                uint64_t connection_timeout_ms =
+                    send_timeout_ms
+                    ? send_timeout_ms
+                    : impl_->get_options().connection_timeout_ms_;
+                if (connection_timeout_ms != 0) {
                     send_timer_.expires_after
                     ( std::chrono::duration_cast<std::chrono::nanoseconds>
-                      ( std::chrono::milliseconds( send_timeout_ms ) ) );
+                      ( std::chrono::milliseconds( connection_timeout_ms ) ) );
                     send_timer_.async_wait(
                         std::bind( &asio_rpc_client::cancel_socket,
                                    this,

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1443,8 +1443,9 @@ public:
         , host_(host)
         , port_(port)
         , ssl_enabled_(ssl_enabled)
+        , streaming_mode_(_impl->get_options().streaming_mode_)
         , ssl_strand_(io_svc.get_executor())
-        , use_strand_(ssl_enabled_ && impl_->get_options().streaming_mode_)
+        , use_strand_(ssl_enabled_ && streaming_mode_)
         , l_(l)
         , send_timer_(io_svc)
         , receive_timer_(io_svc)
@@ -1486,7 +1487,7 @@ public:
     }
 
     bool supports_pipelining() const override {
-        return impl_->get_options().streaming_mode_;
+        return streaming_mode_;
     }
 
 #ifndef SSL_LIBRARY_NOT_FOUND
@@ -1514,7 +1515,7 @@ public:
                       rpc_handler& when_done,
                       uint64_t send_timeout_ms = 0) __override__
     {
-        if (impl_->get_options().streaming_mode_) {
+        if (streaming_mode_) {
             pre_send(req, when_done, send_timeout_ms);
         } else {
             register_req_send(req, when_done, send_timeout_ms);
@@ -1852,7 +1853,7 @@ private:
         // In streaming mode, all `when_done` will be invoked in `close_socket()`.
         // Otherwise, `close_socket()` will do nothing, hence `when_done`
         // should directly be invoked here.
-        if (!impl_->get_options().streaming_mode_) {
+        if (!streaming_mode_) {
             ptr<resp_msg> resp;
             ptr<rpc_exception> except(cs_new<rpc_exception>(err_msg, req));
             when_done(resp, except);
@@ -1876,7 +1877,7 @@ private:
             }
         }
 #endif
-        if (!impl_->get_options().streaming_mode_) {
+        if (!streaming_mode_) {
             return;
         }
 
@@ -2022,7 +2023,7 @@ private:
         if (!err) {
             set_busy_flag(/*receive=*/ false, /*busy=*/ false);
             uint64_t receive_timeout_ms = send_timeout_ms;
-            if (impl_->get_options().streaming_mode_) {
+            if (streaming_mode_) {
                 post_send(req, when_done, receive_timeout_ms);
             } else {
                 register_response_read(req, when_done, receive_timeout_ms);
@@ -2314,7 +2315,7 @@ private:
         receive_timer_.cancel();
         set_busy_flag(/*receive=*/ true, /*busy=*/ false);
 
-        if (!impl_->get_options().streaming_mode_) {
+        if (!streaming_mode_) {
             ptr<rpc_exception> except;
             when_done(rsp, except);
             return;
@@ -2370,6 +2371,14 @@ private:
     std::string host_;
     std::string port_;
     bool ssl_enabled_;
+
+    // A copy of the `streaming_mode_` option, because `close_socket`
+    // reads it while this object is being destroyed, and by then `impl_` may
+    // have outlived its own members: the `io_context` is destroyed after them,
+    // and destroying it abandons the operations that own the last reference to
+    // this client.
+    bool streaming_mode_;
+
     asio::strand<asio::io_context::executor_type> ssl_strand_;
     bool use_strand_;
     uint64_t client_id_;

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -341,8 +341,23 @@ public:
         // this is safe since we only expose ctor to cs_new
         ptr<rpc_session> self = this->shared_from_this();
 
-        cached_address_ = socket_.remote_endpoint().address().to_string();
-        cached_port_ = socket_.remote_endpoint().port();
+        // NOTE: the peer may have reset the connection between `accept` and here,
+        //       in which case there is no remote endpoint to ask for anymore.
+        //       Use the non-throwing overload: the throwing one would propagate
+        //       the error out of the accept handler.
+        ERROR_CODE ec;
+        asio::ip::tcp::endpoint remote = socket_.remote_endpoint(ec);
+        if (ec) {
+            p_er( "session %" PRIu64 " cannot get the remote endpoint: "
+                  "error %d, %s",
+                  session_id_,
+                  ec.value(),
+                  ec.message().c_str() );
+            return;
+        }
+
+        cached_address_ = remote.address().to_string();
+        cached_port_ = remote.port();
         p_in( "session %" PRIu64 " got connection from %s:%u (as a server)",
               session_id_,
               cached_address_.c_str(),
@@ -1346,24 +1361,38 @@ private:
                        ptr<rpc_session> session,
                        const ERROR_CODE& err)
     {
-        if (!err) {
-            asio::ip::tcp::no_delay option(true);
-            session->socket().set_option(option);
-            p_in("receive a incoming rpc connection");
-            session->prepare_handshake();
+        // Re-listen before touching the accepted connection: whatever happens to
+        // this one connection, the listener has to keep accepting the next ones.
+        // Anything thrown below escapes into the worker thread, and if it skipped
+        // the re-listen, this server would never accept a Raft connection again.
+        {
+            std::lock_guard<std::mutex> guard(listener_lock_);
+            if (!stopped_) {
+                // Re-listen only when not stopped,
+                // otherwise crash happens as this class or `acceptor_`
+                // may be destroyed in the meantime.
+                this->start(guard);
+            }
+        }
 
-        } else {
+        if (err) {
             p_er( "failed to accept a rpc connection due to error %d, %s",
                   err.value(), err.message().c_str() );
+            return;
         }
 
-        std::lock_guard<std::mutex> guard(listener_lock_);
-        if (!stopped_) {
-            // Re-listen only when not stopped,
-            // otherwise crash happens as this class or `acceptor_`
-            // may be destroyed in the meantime.
-            this->start(guard);
+        ERROR_CODE ec;
+        asio::ip::tcp::no_delay option(true);
+        session->socket().set_option(option, ec);
+        if (ec) {
+            p_er( "cannot set TCP_NODELAY on an accepted connection: "
+                  "error %d, %s",
+                  ec.value(), ec.message().c_str() );
+            return;
         }
+
+        p_in("receive a incoming rpc connection");
+        session->prepare_handshake();
     }
 
     void remove_session(const ptr<rpc_session>& session) {

--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -1747,9 +1747,9 @@ public:
             send_timer_.expires_after
                    ( std::chrono::duration_cast<std::chrono::nanoseconds>
                      ( std::chrono::milliseconds( send_timeout_ms ) ) );
-            send_timer_.async_wait( std::bind( &asio_rpc_client::cancel_socket,
-                                               this,
-                                               std::placeholders::_1 ) );
+            send_timer_.async_wait( [self](const ERROR_CODE& err) {
+                                        self->cancel_socket(err);
+                                    } );
         }
 
         // Note: without passing `req_buf` to callback function, it will be
@@ -1798,10 +1798,9 @@ private:
                     send_timer_.expires_after
                     ( std::chrono::duration_cast<std::chrono::nanoseconds>
                       ( std::chrono::milliseconds( connection_timeout_ms ) ) );
-                    send_timer_.async_wait(
-                        std::bind( &asio_rpc_client::cancel_socket,
-                                   this,
-                                   std::placeholders::_1 ) );
+                    send_timer_.async_wait( [self](const ERROR_CODE& err) {
+                                                self->cancel_socket(err);
+                                            } );
                 }
                 asio::async_connect
                     ( socket(),
@@ -2093,10 +2092,9 @@ private:
             receive_timer_.expires_after
             ( std::chrono::duration_cast<std::chrono::nanoseconds>
                 ( std::chrono::milliseconds( receive_timeout_ms ) ) );
-            receive_timer_.async_wait(
-                std::bind( &asio_rpc_client::cancel_socket,
-                            this,
-                            std::placeholders::_1 ) );
+            receive_timer_.async_wait( [self](const ERROR_CODE& err) {
+                                           self->cancel_socket(err);
+                                       } );
         }
         ptr<buffer> resp_buf(buffer::alloc(RPC_RESP_HEADER_SIZE));
         aa::read( ssl_enabled_, ssl_socket_, socket_,

--- a/tests/asio/asio_service_test.cxx
+++ b/tests/asio/asio_service_test.cxx
@@ -36,6 +36,7 @@ limitations under the License.
     using asio_error_code = asio::error_code;
 #endif
 
+#include <future>
 #include <unordered_map>
 
 #include <stdio.h>
@@ -2078,6 +2079,94 @@ int custom_io_context_test() {
 }
 
 
+#if !SSL_LIBRARY_NOT_FOUND
+int connection_timeout_test() {
+    reset_log_files();
+
+    const uint16_t MUTE_PORT = 20090;
+
+    // A listener that accepts connections and then says nothing, so that the
+    // SSL handshake of whoever connects to it never finishes.
+    asio::io_context mute_io_context;
+    asio::ip::tcp::acceptor mute_acceptor
+        ( mute_io_context,
+          asio::ip::tcp::endpoint( asio::ip::make_address("127.0.0.1"),
+                                   MUTE_PORT ) );
+    std::list<asio::ip::tcp::socket> mute_sockets;
+    std::function<void()> accept_next = [&]() {
+        mute_sockets.emplace_back(mute_io_context);
+        mute_acceptor.async_accept
+            ( mute_sockets.back(),
+              [&](const asio_error_code& err) {
+                  if (err) return;
+                  accept_next();
+              } );
+    };
+    accept_next();
+    std::thread mute_worker([&]() { mute_io_context.run(); });
+
+    // Stop the listener on every exit path, including a failed check.
+    struct mute_listener_guard {
+        asio::ip::tcp::acceptor& acceptor_;
+        asio::io_context& io_context_;
+        std::thread& worker_;
+        ~mute_listener_guard() {
+            acceptor_.close();
+            io_context_.stop();
+            if (worker_.joinable()) worker_.join();
+        }
+    } guard{mute_acceptor, mute_io_context, mute_worker};
+
+    ptr<logger_wrapper> log_wrap = cs_new<logger_wrapper>("./client.log");
+    ptr<logger> log_inst = log_wrap;
+
+    asio_service::options asio_opt;
+    asio_opt.thread_pool_size_ = 2;
+    asio_opt.enable_ssl_ = true;
+    asio_opt.skip_verification_ = true;
+    asio_opt.server_cert_file_ = "./cert.pem";
+    asio_opt.root_cert_file_ = "./cert.pem"; // self-signed.
+    asio_opt.server_key_file_ = "./key.pem";
+    asio_opt.connection_timeout_ms_ = 1000;
+
+    ptr<asio_service> svc = cs_new<asio_service>(asio_opt, log_inst);
+    ptr<rpc_client> client =
+        svc->create_client( "tcp://127.0.0.1:" + std::to_string(MUTE_PORT) );
+
+    ptr<req_msg> req = cs_new<req_msg>
+                       ( (ulong)0, msg_type::ping_request, 1, 2,
+                         (ulong)0, (ulong)0, (ulong)0 );
+
+    std::promise<ptr<rpc_exception>> promise;
+    std::future<ptr<rpc_exception>> future = promise.get_future();
+    rpc_handler handler = [&promise]( ptr<resp_msg>& resp,
+                                      ptr<rpc_exception>& err ) {
+        (void)resp;
+        promise.set_value(err);
+    };
+
+    timer_helper tt;
+    client->send(req, handler);
+
+    // Without the connection timeout, the handler is never invoked.
+    CHK_TRUE( future.wait_for(std::chrono::seconds(10)) ==
+              std::future_status::ready );
+    uint64_t elapsed_ms = tt.get_us() / 1000;
+    ptr<rpc_exception> result_err = future.get();
+    CHK_NONNULL( result_err.get() );
+    _msg( "the request failed after %zu ms: %s\n",
+          (size_t)elapsed_ms, result_err->what() );
+    CHK_SM( elapsed_ms, (uint64_t)10000 );
+
+    client.reset();
+    svc->stop();
+    svc.reset();
+
+    SimpleLogger::shutdown();
+    return 0;
+}
+#endif
+
 }  // namespace asio_service_test;
 using namespace asio_service_test;
 
@@ -2169,6 +2258,11 @@ int main(int argc, char** argv) {
 
     ts.doTest( "custom io_context test",
                custom_io_context_test );
+
+#if !SSL_LIBRARY_NOT_FOUND
+    ts.doTest( "connection timeout test",
+               connection_timeout_test );
+#endif
 
 #ifdef ENABLE_RAFT_STATS
     _msg("raft stats: ENABLED\n");


### PR DESCRIPTION
Four independent fixes, one commit each. The first three were found in a single `ClickHouse` CI run of an integration test that rotates TLS certificates and kills the Raft connections with `ss --kill` to force the nodes to reconnect: https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?REF=master&sha=7ff5dfc82a99a7952e13b8b476c4ee2232348dd8&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%204%2F8%29

## 1. A reset connection around `accept` costs the server its listener

`rpc_session::prepare_handshake` asks the accepted socket for its remote endpoint through the *throwing* overload of `remote_endpoint`. If the peer's connection is destroyed in the window between `accept` and that call, the socket has no peer address anymore and the call throws `Transport endpoint is not connected`. The exception escapes `asio_rpc_listener::handle_accept` *before* it re-arms the acceptor, so the server never accepts a Raft connection again. Nothing looks fatal in the log: the `asio` worker thread logs `asio worker thread got exception` and goes back to the event loop.

The effect on a Keeper node is severe and silent. It keeps its *outgoing* connections, so it still asks for votes, but nobody can connect to it: it never receives `append_entries` from the leader again, and the peers keep denying its pre-votes because their leader is alive. It stays a candidate that answers `This instance is not currently serving requests` until it is restarted.

Fixed by using the non-throwing overload and dropping the connection when it fails, and by re-arming the acceptor before touching the accepted connection, so that whatever happens to one connection cannot cost the server its listener. `set_option` on the accepted socket is on the same path and gets the same treatment.

Reproduced with a 3-node group while connecting to a Raft port in a loop and destroying the sockets with `ss --kill`, which is what clears the peer address of an already accepted socket (a plain `RST` from the peer does not - the peer address survives it):

- Before: the server logged 621 accepts but only 620 sessions, and the accept right after the missing session was the last one it ever handled. It ignored connection attempts for the remaining three minutes of the run.
- After: 29 such connections were dropped with `cannot get the remote endpoint: error 107, Transport endpoint is not connected`, no exception escaped the event loop, and the group recovered and kept replicating.

## 2. The connection and the SSL handshake are unbounded

`peer::send_req` calls `rpc_client::send` without a timeout, and so does every other Raft RPC - a timeout is only passed for auto-forwarded user requests. Nothing else bounds the wait for a connection, so a peer that accepts the TCP connection but never finishes the SSL handshake keeps the request in flight forever. `when_done` is never invoked, so `peer` keeps its busy flag set and the leader silently stops replicating to that peer, logging only `Server N is busy, skip the request`. It never recovers, because nothing frees the busy flag without the callback.

That is exactly what the new leader did to the node from bug 1 in the failing run: it logged `skipped sending msg to 2 too long time` and then `Server 2 is busy, skip the request` for the rest of the run, and never retried.

Fixed by giving the connection its own timeout, `connection_timeout_ms_`, 10 seconds by default, covering the TCP connection and the SSL handshake. The timer and its `cancel_socket` handler already existed; they were simply never armed for a request that carries no timeout of its own. A request that does pass a timeout keeps using it, and neither the send nor the receive phase is affected: bounding those would break large `append_entries` batches and snapshot transfers.

The new `connection timeout test` points a client at a listener that accepts the connection and then says nothing. With `connection_timeout_ms_` at zero, which is what the behaviour was before, the request never completes and the test fails waiting for the callback; with the default it fails after 1 second with `failed SSL handshake with peer 2, error 125, Operation aborted`.

## 3. An rpc client reads the service options while being destroyed

`asio_rpc_client::close_socket` reads `impl_->get_options().streaming_mode_`, and the destructor calls it. That is a read of a destroyed object on the ordinary teardown path: `asio_service_impl` declares `io_svc_` before `my_opt_`, so `my_opt_` is destroyed first, and destroying the `io_context` after it abandons the pending operations - which hold the last reference to the clients. MemorySanitizer with `-fsanitize-memory-use-after-dtor` reported it as `use-of-uninitialized-value` in `close_socket` while a Keeper node was shutting down in the same run.

Fixed by copying the flag into the client at construction, next to `use_strand_` which already does exactly that, and using the copy everywhere in the client. The options are set once in the `asio_service_impl` constructor and never change, so the copy cannot go stale.

## 4. The timeout timers of an rpc client are bound to a raw `this`

Noticed while working on fix 2, and it belongs with it: `steady_timer::cancel` does not unqueue a completion that the `io_context` has already accepted, so a `cancel_socket` handler cancelled on the way out - which is what `connected` and `handle_handshake` do on every connection - can still run after the request has failed, the peer has dropped `rpc_`, and the client has been destroyed. It captures the `shared_ptr` now, as every other handler of this class does. This was hard to reach while the connection timer was never armed; fix 2 arms it for every connection, so every connection now cancels a timer.

## Verification

Beyond the reproduction of fix 1 above and the new test for fix 2, the whole `asio_service_test` suite was run locally on `aarch64`.